### PR TITLE
ci: npm Trusted Publishing (OIDC) + first-class workflow_dispatch releases

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -3,16 +3,24 @@ name: Release anaf-cli
 # ──────────────────────────────────────────────────────────────
 # Trigger:
 #   • Push of a tag matching cli-v*.*.* (e.g. cli-v0.1.0 or cli-v1.0.0-preview.1)
-#   • Manual run via workflow_dispatch for testing
+#   • Manual run via workflow_dispatch — dry-run by default; with
+#     dry_run=false it performs the full release (the GitHub Release step
+#     creates the cli-v* tag itself from the version in cli/package.json).
 #
 # Build matrix:
 #   • npm package (Ubuntu)
-#   • SEA binary for darwin-arm64, darwin-x64, linux-x64
+#   • SEA binary for darwin-arm64, linux-x64
 #
 # Outputs:
-#   • GitHub Release (draft) with the 3 tar.gz SEA artifacts, the npm .tgz,
+#   • GitHub Release with the SEA tar.gz artifacts, the npm .tgz,
 #     and a SHA256SUMS file
 #   • npm publish of the `anaf-cli` package (skipped on dry runs)
+#   • Homebrew tap formula update (skipped on dry runs)
+#
+# npm auth uses Trusted Publishing (OIDC) — no NPM_TOKEN secret involved.
+# The package must have this workflow configured as a Trusted Publisher on
+# npmjs.com. The Homebrew tap push still uses HOMEBREW_TAP_TOKEN (cross-repo
+# git push is not covered by OIDC).
 # ──────────────────────────────────────────────────────────────
 on:
   push:
@@ -44,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:
@@ -97,7 +105,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:
@@ -137,7 +145,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
     permissions:
-      contents: write
+      contents: write # GitHub Release + tag creation on dispatch runs
+      id-token: write # npm Trusted Publishing (OIDC)
     env:
       CLI_VERSION: ${{ needs.test-and-pack.outputs.cli_version }}
     steps:
@@ -145,13 +154,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org/'
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -170,8 +178,11 @@ jobs:
         with:
           files: ./release-final/*
           body_path: ./release-final/SHA256SUMS
-          # Publish on tag pushes so Homebrew tap URLs resolve immediately;
-          # workflow_dispatch dry-runs are gated by the job-level `if:` above.
+          # On tag pushes tag_name matches the pushed tag; on workflow_dispatch
+          # runs (dry-runs are gated by the job-level `if:` above) the release
+          # creates the cli-v* tag itself at the current commit.
+          tag_name: cli-v${{ needs.test-and-pack.outputs.cli_version }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: ${{ contains(needs.test-and-pack.outputs.cli_version, '-') }}
       - name: Install (workspace, for publish)
@@ -180,16 +191,12 @@ jobs:
         run: |
           pnpm --filter @florinszilagyi/anaf-ts-sdk run build
           pnpm --filter @florinszilagyi/anaf-cli run build
-      - name: Publish to npm (dry-run default)
+      # Dry-runs never reach this job (see the job-level `if:`), so publish
+      # unconditionally — both tag pushes and real dispatch runs are releases.
+      - name: Publish to npm
         run: |
           cd cli
-          if [ "${{ github.event_name }}" = "push" ]; then
-            pnpm publish --no-git-checks --access public
-          else
-            pnpm publish --no-git-checks --access public --dry-run
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          pnpm publish --no-git-checks --access public
 
   # ─────────────────────────── Homebrew tap update ──────────
   # Renders cli/Formula/anaf-cli.rb with the published version and the SHA256
@@ -197,7 +204,7 @@ jobs:
   # florin-szilagyi/homebrew-anaf-cli tap repo. Skipped on dry-runs.
   homebrew:
     needs: [test-and-pack, publish]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/mcp-publish.yaml
+++ b/.github/workflows/mcp-publish.yaml
@@ -1,5 +1,16 @@
 name: Publish MCP (anaf-mcp)
 
+# ──────────────────────────────────────────────────────────────
+# Trigger:
+#   • Push of a tag matching mcp-v*.*.*
+#   • Manual run via workflow_dispatch — dry-run by default; with
+#     dry_run=false it publishes for real and creates the mcp-v* tag itself.
+#
+# npm auth uses Trusted Publishing (OIDC): the job mints a short-lived
+# credential via id-token permissions — no NPM_TOKEN secret involved.
+# Each package must have this workflow configured as a Trusted Publisher
+# on npmjs.com before the publish step can succeed.
+# ──────────────────────────────────────────────────────────────
 on:
   push:
     tags:
@@ -8,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Build and test but skip npm publish'
+        description: 'Build and test but skip npm publish and tag creation'
         required: false
         default: 'true'
 
@@ -16,7 +27,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # push the mcp-v* tag on real dispatch runs
+      id-token: write # npm Trusted Publishing (OIDC)
 
     steps:
       - name: Checkout
@@ -24,14 +36,13 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install workspace deps
         run: pnpm install --frozen-lockfile
@@ -44,13 +55,24 @@ jobs:
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
         run: |
           cd mcp
-          if [ "$EVENT_NAME" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ] || [ "$DRY_RUN_INPUT" != "true" ]; then
             pnpm publish --no-git-checks --access public
           else
             pnpm publish --no-git-checks --access public --dry-run
+          fi
+
+      - name: Create and push release tag
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        run: |
+          VERSION=$(node -p "require('./mcp/package.json').version")
+          TAG="mcp-v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,16 @@
 name: Publish SDK (anaf-ts-sdk)
 
+# ──────────────────────────────────────────────────────────────
+# Trigger:
+#   • Push of a tag matching sdk-v*.*.*
+#   • Manual run via workflow_dispatch — dry-run by default; with
+#     dry_run=false it publishes for real and creates the sdk-v* tag itself.
+#
+# npm auth uses Trusted Publishing (OIDC): the job mints a short-lived
+# credential via id-token permissions — no NPM_TOKEN secret involved.
+# Each package must have this workflow configured as a Trusted Publisher
+# on npmjs.com before the publish step can succeed.
+# ──────────────────────────────────────────────────────────────
 on:
   push:
     tags:
@@ -7,18 +18,18 @@ on:
       - 'sdk-v*.*.*-*'
   workflow_dispatch:
     inputs:
-      release_type:
-        description: 'Version bump (patch / minor / major)'
+      dry_run:
+        description: 'Build and test but skip npm publish and tag creation'
         required: false
-        default: 'patch'
+        default: 'true'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      packages: write
+      contents: write # push the sdk-v* tag on real dispatch runs
+      id-token: write # npm Trusted Publishing (OIDC)
 
     steps:
       - name: Checkout
@@ -28,13 +39,12 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install packages
         run: pnpm install --frozen-lockfile
@@ -46,6 +56,25 @@ jobs:
         run: pnpm --filter @florinszilagyi/anaf-ts-sdk run validate
 
       - name: Publish SDK
-        run: pnpm --filter @florinszilagyi/anaf-ts-sdk publish --access public --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        run: |
+          cd sdk
+          if [ "$EVENT_NAME" = "push" ] || [ "$DRY_RUN_INPUT" != "true" ]; then
+            pnpm publish --access public --no-git-checks
+          else
+            pnpm publish --access public --no-git-checks --dry-run
+          fi
+
+      - name: Create and push release tag
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        run: |
+          VERSION=$(node -p "require('./sdk/package.json').version")
+          TAG="sdk-v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ All errors are `CliError` instances with a `category` (`generic`=1, `user_input`
 ## Release
 
 - SDK: push a tag `sdk-v*.*.*` triggers `publish.yaml` (npm publish).
-- CLI: push a tag `cli-v*.*.*` triggers `cli-release.yaml` (builds SEA binaries for darwin-arm64/x64 + linux-x64, publishes npm, drafts GitHub Release).
+- CLI: push a tag `cli-v*.*.*` triggers `cli-release.yaml` (builds SEA binaries for darwin-arm64 + linux-x64, publishes npm, creates GitHub Release, updates Homebrew tap).
 - MCP: push a tag `mcp-v*.*.*` triggers `mcp-publish.yaml` (npm publish).
+- Alternatively, each workflow can be run via `workflow_dispatch` with `dry_run=false` — it publishes the version currently in the package's `package.json` and creates the release tag itself. The default `dry_run=true` builds and tests without publishing.
+- npm auth uses Trusted Publishing (OIDC) — each package is bound to its workflow on npmjs.com; there is no `NPM_TOKEN` secret.
 - Homebrew tap: `florin-szilagyi/homebrew-anaf-cli` — formula at `cli/Formula/anaf-cli.rb` (SHA256 placeholders updated per release).


### PR DESCRIPTION
## Summary

Removes the `NPM_TOKEN` dependency from all three release workflows and makes `workflow_dispatch` a real release path. Context: the `mcp-v1.0.0` release run (July 1) failed at `npm publish` with `E404` on PUT — the classic signature of an expired automation token. Trusted Publishing (OIDC) eliminates token rotation entirely, and the dispatch fixes mean releases can be triggered from the Actions UI (or API) without pushing tags manually.

### All three workflows (`publish.yaml`, `mcp-publish.yaml`, `cli-release.yaml`)

- **npm auth → Trusted Publishing (OIDC):** publishing jobs get `id-token: write`; `NODE_AUTH_TOKEN` and setup-node's `registry-url` (which writes an `.npmrc` auth line referencing the now-unneeded env var) are removed.
- **pnpm 9 → 10** in every job — needed for pnpm's trusted-publishing support; lockfile v9 is shared by both major versions (verified locally with `pnpm install --frozen-lockfile` on pnpm 10.33). pnpm is kept for publishing because `mcp` has a runtime `workspace:*` dependency on the SDK that must be rewritten at publish time.
- **Consistent dispatch contract:** `dry_run` input, default `'true'`. Real publish on tag push **or** dispatch with `dry_run=false`. Previously dispatch was *always* dry-run regardless of the input (`event_name == push` checks), and `publish.yaml`'s `release_type` input was declared but never used — it is replaced by `dry_run`.
- **Dispatch releases create their own tags** from the version in the package's `package.json`: `publish.yaml`/`mcp-publish.yaml` push `sdk-v*`/`mcp-v*` via a guarded step (skipped if the tag already exists; `GITHUB_TOKEN` pushes don't re-trigger workflows), and `cli-release.yaml` sets `tag_name`/`target_commitish` on the GitHub Release step so the release creates `cli-v*` itself.

### `cli-release.yaml` specifics

- The npm publish step previously dry-ran even on dispatch runs with `dry_run=false` (while still creating a GitHub Release). It is now unconditional inside the job, which is already gated by the job-level dry-run `if:`.
- The Homebrew tap job now also runs on real dispatch releases (was tag-push only). It keeps `HOMEBREW_TAP_TOKEN` — cross-repo git push is not covered by OIDC.
- Stale header comments fixed (release is not a draft; darwin-x64 is no longer in the matrix).

### `CLAUDE.md`

Documents the dispatch release path and the OIDC auth model.

## ⚠️ Required manual setup before the next release

On npmjs.com, for **each** package, add a Trusted Publisher (package → Settings → Trusted Publisher → GitHub Actions):

| Package | Repository | Workflow filename |
|---|---|---|
| `@florinszilagyi/anaf-ts-sdk` | `florin-szilagyi/ts-anaf` | `publish.yaml` |
| `@florinszilagyi/anaf-cli` | `florin-szilagyi/ts-anaf` | `cli-release.yaml` |
| `@florinszilagyi/anaf-mcp` | `florin-szilagyi/ts-anaf` | `mcp-publish.yaml` |

(Leave "environment" empty.) Until this is configured, real publishes will fail with an npm auth error. Afterwards the `NPM_TOKEN` repo secret can be deleted. Also make sure each package's **Publishing access** setting permits automation (not the strict "require 2FA for publish").

## Verification

- All three workflow files parse as valid YAML.
- `pnpm install --frozen-lockfile` passes under pnpm 10 with the existing v9 lockfile.
- Dry-run semantics preserved: a plain `workflow_dispatch` (default `dry_run=true`) still builds, tests, and `--dry-run`-publishes without touching npm, tags, releases, or the tap.

## Releasing the pending 1.5.0 / 1.1.0 versions

After merging **and** configuring the trusted publishers, the pending releases (SDK 1.5.0, CLI 1.1.0, MCP 1.1.0) can be shipped either by pushing the three tags, or — now — by running each workflow from the Actions tab with `dry_run=false`, which publishes and creates the tags automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR)_