### PR TITLE
fix(cli): regenerate COMMANDS.md, gate gen-docs:check in verify, drop cli/.npmrc

### DIFF
--- a/cli/.npmrc
+++ b/cli/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/cli/COMMANDS.md
+++ b/cli/COMMANDS.md
@@ -501,6 +501,9 @@ Options:
   --line <line>                       invoice line:
                                       "desc|qty|unitPrice|taxPct[|unitCode]"
                                       (default: [])
+  --invoice-type-code <code>          invoice type code (BT-3): 380 commercial
+                                      (default), 384 corrective, 389
+                                      self-billed, 751 accounting
   --currency <code>                   currency code
   --tax-currency-tax-amount <amount>  total VAT in RON (required when
                                       --currency is not RON, CIUS-RO BR-53)

--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=smoke",
     "test:smoke": "jest --testPathPattern=smoke --runInBand",
-    "verify": "pnpm run lint && pnpm run build && pnpm run test",
+    "verify": "pnpm run lint && pnpm run gen-docs:check && pnpm run build && pnpm run test",
     "gen-docs": "tsx scripts/gen-docs.ts",
     "gen-docs:check": "tsx scripts/gen-docs.ts --out COMMANDS.md.tmp && diff COMMANDS.md COMMANDS.md.tmp && rm COMMANDS.md.tmp || (rm -f COMMANDS.md.tmp && echo 'COMMANDS.md is stale — run: pnpm gen-docs' && exit 1)"
   },


### PR DESCRIPTION
## Summary

Fixes the two remaining blockers found in today's failed `cli-v1.1.0` release run (plus one latent OIDC issue):

- **`cli/COMMANDS.md` regenerated** — the release workflow's `gen-docs:check` gate failed because the docs were not regenerated when the `--invoice-type-code` flag was added in #10 (the flag's help text was missing). This was the actual failure of the `cli-v1.1.0` tag run; all 367 tests passed.
- **`gen-docs:check` added to the CLI `verify` script** — `pnpm run verify` (the local/CI gate used everywhere) previously did not include the docs freshness check, so a stale `COMMANDS.md` could only be caught at release time. Now it fails fast.
- **`cli/.npmrc` removed** — it contained `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, which breaks `pnpm publish` under the Trusted Publishing (OIDC) flow from #11 where that env var no longer exists (npm errors on the unexpandable variable), and it emitted a config warning on every local pnpm invocation in `cli/`.

## Verification

`pnpm run verify` passes end-to-end (exit 0) with the strengthened CLI verify: SDK build, CLI lint + **gen-docs:check** + build + 367 tests, MCP lint/build/44 tests.

## Post-merge release steps (SDK 1.5.0 / CLI 1.1.0 / MCP 1.1.0)

The three existing tags point at the pre-#11 merge commit, so tag re-runs would use the old token-based workflows (SDK/MCP already failed with `EOTP` there). Cleanest path after merging this:

1. Configure the npm Trusted Publishers for the three packages (see #11's table), if not done yet.
2. Delete the stale tags: `git push origin :refs/tags/sdk-v1.5.0 :refs/tags/cli-v1.1.0 :refs/tags/mcp-v1.1.0`
3. Run each workflow from the Actions tab with `dry_run=false` — they publish via OIDC and recreate the tags at the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--invoice-type-code` option to `anaf-cli ubl build`, including supported codes and defaults in the documentation.

* **Chores**
  * Updated verification checks to validate generated documentation.
  * Removed registry authentication configuration from the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->