### PR TITLE
ci: use Node 24 on publish jobs so npm supports Trusted Publishing

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -156,9 +156,12 @@ jobs:
         with:
           version: 10
           run_install: false
+      # This job publishes but builds no SEA binary, so it is exempt from the
+      # NODE_VERSION pin: Node >= 22.14 gives npm CLI >= 11.5.1, the minimum
+      # for npm Trusted Publishing (OIDC); pnpm publish delegates to that npm.
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 24
           cache: pnpm
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/mcp-publish.yaml
+++ b/.github/workflows/mcp-publish.yaml
@@ -39,9 +39,11 @@ jobs:
           version: 10
           run_install: false
 
+      # Node >= 22.14 so the bundled npm CLI is >= 11.5.1 — the minimum for
+      # npm Trusted Publishing (OIDC); pnpm publish delegates to the npm in PATH.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install workspace deps

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,9 +41,11 @@ jobs:
         with:
           version: 10
           run_install: false
+      # Node >= 22.14 so the bundled npm CLI is >= 11.5.1 — the minimum for
+      # npm Trusted Publishing (OIDC); pnpm publish delegates to the npm in PATH.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install packages


### PR DESCRIPTION
## Summary

Fixes the `ENEEDAUTH` failures from today's OIDC release attempts (both the `sdk-v1.5.0` tag run and the `workflow_dispatch` run at the same commit).

**Root cause:** the publish jobs ran on Node 20, whose bundled npm CLI is **10.8.2** (visible in the run's "Environment details"). npm Trusted Publishing requires **npm CLI ≥ 11.5.1 on Node ≥ 22.14** ([npm docs](https://docs.npmjs.com/trusted-publishers/)), and `pnpm publish` delegates the actual registry call to the npm found in PATH — so no OIDC token exchange ever happened and npm fell through to "need auth / `npm adduser`".

**Change:** bump `setup-node` to `node-version: 24` (bundles npm 11.x) on the three publishing jobs:

- `publish.yaml` (SDK)
- `mcp-publish.yaml` (MCP)
- `cli-release.yaml` — **publish job only**. The `test-and-pack`/`build-sea` jobs keep the pinned `NODE_VERSION: 20.18.1`, which exists for SEA blob/binary byte-matching; the publish job builds no SEA binary, so it is exempt (comment added in the workflow).

## Also verify on npmjs.com (not fixable from the repo)

`ENEEDAUTH` is also what npm returns when the Trusted Publisher config doesn't match. Field values are case-sensitive and exact — note this repo's workflows use the **`.yaml`** extension, not `.yml`:

| Package | Repository | Workflow filename |
|---|---|---|
| `@florinszilagyi/anaf-ts-sdk` | `florin-szilagyi/ts-anaf` | `publish.yaml` |
| `@florinszilagyi/anaf-cli` | `florin-szilagyi/ts-anaf` | `cli-release.yaml` |
| `@florinszilagyi/anaf-mcp` | `florin-szilagyi/ts-anaf` | `mcp-publish.yaml` |

Leave the "environment" field empty (the workflows declare none).

## After merging

Re-run the releases either by re-pushing the tags on the new `main` HEAD, or from the Actions tab with `dry_run=false` (creates the tags automatically). `sdk-v1.5.0` currently points at the pre-fix commit — dispatch runs skip existing tags, so either leave it or delete/re-tag for a clean pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR)_