### PR TITLE
fix: point sdk/mcp package.json repository at ts-anaf for provenance validation

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -3,6 +3,15 @@
   "version": "1.1.0",
   "description": "MCP server for the ANAF e-Factura SDK — exposes lookup, UBL, upload, status, download, messages, validate as tools",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/florin-szilagyi/ts-anaf.git",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/florin-szilagyi/ts-anaf#readme",
+  "bugs": {
+    "url": "https://github.com/florin-szilagyi/ts-anaf/issues"
+  },
   "author": {
     "name": "Florin Szilagyi",
     "url": "https://github.com/florin-szilagyi"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -20,11 +20,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/florin-szilagyi/efactura-anaf-ts-sdk.git"
+    "url": "git+https://github.com/florin-szilagyi/ts-anaf.git",
+    "directory": "sdk"
   },
-  "homepage": "https://github.com/florin-szilagyi/efactura-anaf-ts-sdk#readme",
+  "homepage": "https://github.com/florin-szilagyi/ts-anaf#readme",
   "bugs": {
-    "url": "https://github.com/florin-szilagyi/efactura-anaf-ts-sdk/issues"
+    "url": "https://github.com/florin-szilagyi/ts-anaf/issues"
   },
   "keywords": [
     "anaf",


### PR DESCRIPTION
## Summary

The last piece of the OIDC release puzzle. Today's dispatch runs got past authentication — the provenance statement was **signed and published to the Sigstore transparency log** — but npm then rejected the publish with `E422`:

- **SDK**: `"repository.url" is "git+https://github.com/florin-szilagyi/efactura-anaf-ts-sdk.git", expected to match "https://github.com/florin-szilagyi/ts-anaf" from provenance` — the URL still pointed at the repo's pre-rename name.
- **MCP**: `"repository.url" is ""` — no `repository` field at all.
- **CLI** already had the correct URL, which is exactly why `anaf-cli@1.1.0` published successfully in the same batch.

Trusted publishing generates provenance by default, and npm validates that `package.json`'s `repository.url` matches the repository the workflow actually ran from.

## Changes

- `sdk/package.json`: `repository.url` → `git+https://github.com/florin-szilagyi/ts-anaf.git` (+ `"directory": "sdk"`); `homepage` and `bugs` updated off the stale repo name too.
- `mcp/package.json`: adds the missing `repository` (with `"directory": "mcp"`), `homepage`, and `bugs` fields.

Metadata-only — no code changes, no version bumps (1.5.0 / 1.1.0 are still unpublished for these two packages).

## After merging

Re-run **Publish SDK** and **Publish MCP** from the Actions tab with `dry_run=false` (or ask Claude to dispatch them). The CLI release is already complete and needs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEXvBDEDJMz4Gk2f1wkVmR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository, homepage, and issue-tracking metadata for the MCP package.
  * Updated SDK package metadata to reflect its current repository location and subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->