### PR TITLE
fix(ubl): correct VAT breakdown for mixed-rate invoices with document-level allowances (1.5.1)

### DIFF
--- a/sdk/src/ubl/InvoiceBuilder.ts
+++ b/sdk/src/ubl/InvoiceBuilder.ts
@@ -376,13 +376,15 @@ interface ResolvedAllowanceTaxCategory {
  * Resolution order:
  *  1. If both `taxCategoryId` and `taxPercent` are explicit on the allowance, use them.
  *  2. If `taxCategoryId` is explicit but `taxPercent` is missing, infer the percent from
- *     the matching line tax group (or default to 0 for 'Z'/'O', error if 'S' has no match).
+ *     the single matching line tax group (or default to 0 for 'Z'/'O', error if 'S' has
+ *     no match, error if several line groups share the category at different rates).
  *  3. If neither is explicit and the lines have a single tax group, inherit from it.
  *  4. Otherwise (lines have mixed tax groups), throw — caller must disambiguate.
  *
  * @throws {AnafValidationError} If lines have mixed tax categories and the allowance
- *   does not specify `taxCategoryId`, or if an explicit `taxCategoryId` references
- *   a standard-rated ('S') category with no matching line group to infer the percent from.
+ *   does not specify `taxCategoryId`, if an explicit `taxCategoryId` references
+ *   a standard-rated ('S') category with no matching line group to infer the percent from,
+ *   or if it references a category carried by several line groups at different rates.
  */
 function resolveAllowanceTaxCategory(
   ac: DocumentAllowanceCharge,
@@ -405,11 +407,24 @@ function resolveAllowanceTaxCategory(
 
   // Explicit category provided.
   if (ac.taxCategoryId) {
-    const matching = taxGroups.find((g) => g.categoryId === ac.taxCategoryId);
+    const matches = taxGroups.filter((g) => g.categoryId === ac.taxCategoryId);
+    const matching = matches[0];
     let percent: number;
     if (ac.taxPercent !== undefined) {
       percent = ac.taxPercent;
     } else if (matching) {
+      // A category does not identify a tax group on its own: category (BT-118) and rate
+      // (BT-119) are independent, so 'S' can cover several rates. Inheriting the first
+      // match would file VAT at the wrong rate on an invoice whose totals still
+      // reconcile — undetectable downstream — so refuse to guess.
+      const candidatePercents = Array.from(new Set(matches.map((g) => g.percent)));
+      if (ac.taxCategoryId !== 'O' && candidatePercents.length > 1) {
+        throw new AnafValidationError(
+          `${label}: taxPercent is required because invoice lines carry several '${ac.taxCategoryId}' VAT rates ` +
+            `(${candidatePercents.map((p) => `${p}%`).join(', ')}) — category and rate are independent, so ` +
+            `'${ac.taxCategoryId}' alone does not identify a tax group; set taxPercent to the rate this applies to`
+        );
+      }
       percent = matching.percent;
     } else if (ac.taxCategoryId === 'Z') {
       percent = 0;

--- a/sdk/src/ubl/InvoiceBuilder.ts
+++ b/sdk/src/ubl/InvoiceBuilder.ts
@@ -445,13 +445,38 @@ function resolveAllowanceTaxCategory(
 }
 
 /**
- * Apply resolved document-level allowances/charges to the per-category tax groups.
+ * Identity of a VAT breakdown group (BG-23), used to key the tax-group map.
+ *
+ * In EN 16931 / CIUS-RO the VAT category (BT-118) and the VAT rate (BT-119) are
+ * independent: Romania's 21% and 11% rates are both category 'S'. A group is
+ * therefore identified by the (category, percent) pair, not by the category alone —
+ * keying by category would silently merge two distinct rates into one
+ * `cac:TaxSubtotal`. Mirrors the key used by {@link groupLinesByTax}.
+ *
+ * Category 'O' (not subject to VAT) is the one exception: BR-O-05 forbids
+ * `cbc:Percent` on it and its `taxAmount` is always 0, so its percent carries no
+ * meaning and is deliberately excluded from the key. That keeps a resolved 'O'
+ * allowance (percent `undefined`) and an 'O' line group (percent `0`) in the same
+ * group instead of splitting them into two spurious 'O' subtotals.
+ */
+function taxGroupKey(categoryId: string, percent: number | undefined): string {
+  return categoryId === 'O' ? 'O' : `${categoryId}-${percent ?? 0}`;
+}
+
+/**
+ * Apply resolved document-level allowances/charges to the per-group tax groups.
  *
  * For each allowance (`chargeIndicator=false`), the matching group's `taxableAmount`
  * is decreased; for each charge (`chargeIndicator=true`), it is increased. The
  * group's `taxAmount` is then re-derived from the adjusted taxable amount and the
  * group's percent. This satisfies CIUS-RO BR-CO-17 / BR-DEC-19, where each
  * `cac:TaxSubtotal` reflects the apportioned base after document-level adjustments.
+ *
+ * Groups are matched on the (category, percent) pair — see {@link taxGroupKey}.
+ *
+ * Emission order is deterministic: the returned array lists the line tax groups
+ * first, in the order {@link groupLinesByTax} produced them, followed by any group
+ * created solely by an allowance/charge, in the order those appear on the invoice.
  *
  * Returns a new array; the input array is not mutated.
  */
@@ -464,13 +489,14 @@ function applyAllowancesToTaxGroups(
   }
 
   // Clone so we don't mutate the caller's groups.
-  const groupsByCategory = new Map<string, TaxGroup>();
-  taxGroups.forEach((g) => groupsByCategory.set(g.categoryId, { ...g }));
+  const groupsByKey = new Map<string, TaxGroup>();
+  taxGroups.forEach((g) => groupsByKey.set(taxGroupKey(g.categoryId, g.percent), { ...g }));
 
   resolvedAllowances.forEach(({ ac, resolved }) => {
-    let group = groupsByCategory.get(resolved.categoryId);
+    const key = taxGroupKey(resolved.categoryId, resolved.percent);
+    let group = groupsByKey.get(key);
     if (!group) {
-      // No line was rated at this category — create an empty group so the
+      // No line was rated at this category/percent — create an empty group so the
       // adjustment still appears in the VAT breakdown.
       group = {
         categoryId: resolved.categoryId,
@@ -479,7 +505,7 @@ function applyAllowancesToTaxGroups(
         taxAmount: 0,
         exemptionReasonCode: resolved.exemptionReasonCode,
       };
-      groupsByCategory.set(resolved.categoryId, group);
+      groupsByKey.set(key, group);
     }
 
     const delta = ac.chargeIndicator ? ac.amount : -ac.amount;
@@ -488,7 +514,7 @@ function applyAllowancesToTaxGroups(
 
   // Re-derive taxAmount from the adjusted taxableAmount, except for category 'O'
   // (not subject to VAT) which always has taxAmount = 0 and no percent.
-  groupsByCategory.forEach((group) => {
+  groupsByKey.forEach((group) => {
     if (group.categoryId === 'O') {
       group.taxAmount = 0;
     } else {
@@ -496,7 +522,7 @@ function applyAllowancesToTaxGroups(
     }
   });
 
-  return Array.from(groupsByCategory.values());
+  return Array.from(groupsByKey.values());
 }
 
 /**

--- a/sdk/tests/ublBuilder.unit.test.ts
+++ b/sdk/tests/ublBuilder.unit.test.ts
@@ -1690,6 +1690,258 @@ describe('UblBuilder Tests', () => {
     });
   });
 
+  describe('Multi-rate VAT groups with document-level AllowanceCharge', () => {
+    /**
+     * EN 16931 / CIUS-RO treat the VAT category (BT-118) and the VAT rate (BT-119) as
+     * independent: Romania's 21% and 11% rates are both category 'S'. A tax group is
+     * therefore identified by the (category, percent) PAIR, never by the category alone.
+     *
+     * These tests pin that a document-level allowance/charge — the only thing that makes
+     * the builder rewrite the tax groups — keeps one cac:TaxSubtotal per distinct rate.
+     *
+     * Emission order: line tax groups first, in first-appearance order of the lines, then
+     * any group created solely by an allowance/charge, in the order those appear.
+     */
+
+    /** All cac:TaxSubtotal blocks, in document order. */
+    const taxSubtotalsOf = (xml: string): string[] => xml.match(/<cac:TaxSubtotal>[\s\S]*?<\/cac:TaxSubtotal>/g) ?? [];
+
+    /** Two 100 RON lines at Romania's 21% and 11% rates — both category 'S'. */
+    const twoRateLines = [
+      { description: 'Standard rated', quantity: 1, unitPrice: 100, taxPercent: 21 },
+      { description: 'Reduced rated', quantity: 1, unitPrice: 100, taxPercent: 11 },
+    ];
+
+    test('two rates + one allowance per rate: each rate keeps its own TaxSubtotal', () => {
+      // A document-level discount on a mixed-rate invoice must be split into one
+      // allowance per distinct VAT rate (CIUS-RO). Before the (category, percent) keying
+      // the second group overwrote the first: 1 subtotal, VAT 8.80, TaxInclusive 188.80.
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Discount 21% share', taxCategoryId: 'S', taxPercent: 21 },
+          { chargeIndicator: false, amount: 10, reason: 'Discount 11% share', taxCategoryId: 'S', taxPercent: 11 },
+        ],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(2);
+
+      // 21% group: 100 − 10 = 90 base, 90 * 21% = 18.90 VAT.
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">90.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">18.90</cbc:TaxAmount>');
+      expect(subtotals[0]).toContain('<cbc:ID>S</cbc:ID>');
+      expect(subtotals[0]).toContain('<cbc:Percent>21.00</cbc:Percent>');
+
+      // 11% group: 100 − 10 = 90 base, 90 * 11% = 9.90 VAT.
+      expect(subtotals[1]).toContain('<cbc:TaxableAmount currencyID="RON">90.00</cbc:TaxableAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxAmount currencyID="RON">9.90</cbc:TaxAmount>');
+      expect(subtotals[1]).toContain('<cbc:ID>S</cbc:ID>');
+      expect(subtotals[1]).toContain('<cbc:Percent>11.00</cbc:Percent>');
+
+      // Totals: 18.90 + 9.90 = 28.80 VAT on a 180.00 taxable base.
+      expect(xml).toContain('<cbc:LineExtensionAmount currencyID="RON">200.00</cbc:LineExtensionAmount>');
+      expect(xml).toContain('<cbc:AllowanceTotalAmount currencyID="RON">20.00</cbc:AllowanceTotalAmount>');
+      expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="RON">180.00</cbc:TaxExclusiveAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">208.80</cbc:TaxInclusiveAmount>');
+      expect(xml).toContain('<cbc:PayableAmount currencyID="RON">208.80</cbc:PayableAmount>');
+
+      // The collapsed-group signature must not reappear.
+      expect(xml).not.toContain('<cbc:TaxInclusiveAmount currencyID="RON">188.80</cbc:TaxInclusiveAmount>');
+
+      // Both AllowanceCharge blocks keep their own rate.
+      const acBlocks = xml.match(/<cac:AllowanceCharge>[\s\S]*?<\/cac:AllowanceCharge>/g) ?? [];
+      expect(acBlocks).toHaveLength(2);
+      expect(acBlocks[0]).toContain('<cbc:Percent>21.00</cbc:Percent>');
+      expect(acBlocks[1]).toContain('<cbc:Percent>11.00</cbc:Percent>');
+    });
+
+    test('allowance at a rate no line carries gets its own group instead of eating another S group', () => {
+      // Single 21% line, allowance declared at 11% → the fallback must synthesise a
+      // separate (S, 11) group. Before the fix the allowance was subtracted from the
+      // 21% group instead: 1 subtotal of 90.00 / 18.90.
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        lines: [{ description: 'Standard rated', quantity: 1, unitPrice: 100, taxPercent: 21 }],
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Reduced-rate rebate', taxCategoryId: 'S', taxPercent: 11 },
+        ],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(2);
+
+      // The 21% group is untouched — this is the whole point.
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">21.00</cbc:TaxAmount>');
+      expect(subtotals[0]).toContain('<cbc:Percent>21.00</cbc:Percent>');
+
+      // The synthesised 11% group carries the adjustment alone. A negative base is the
+      // pre-existing semantics of the "no line at this rate" fallback (an allowance can
+      // only subtract); the fix changes where it lands, not how it is computed.
+      expect(subtotals[1]).toContain('<cbc:TaxableAmount currencyID="RON">-10.00</cbc:TaxableAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxAmount currencyID="RON">-1.10</cbc:TaxAmount>');
+      expect(subtotals[1]).toContain('<cbc:Percent>11.00</cbc:Percent>');
+
+      // 21.00 − 1.10 = 19.90 VAT on a 90.00 base.
+      expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="RON">90.00</cbc:TaxExclusiveAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">109.90</cbc:TaxInclusiveAmount>');
+    });
+
+    test("category 'O' allowance merges into the invoice's single 'O' group (percent is not part of the O key)", () => {
+      // Category 'O' has no meaningful percent (BR-O-05 forbids cbc:Percent) and always
+      // has taxAmount = 0, so percent must be excluded from its group key. The line group
+      // is stored as (O, 0) while the resolved allowance carries percent undefined — a
+      // naive `${categoryId}-${percent}` key would split those into two 'O' subtotals.
+      const nonVatSupplier: Party = {
+        ...mockTestData.invoiceData.supplier,
+        vatNumber: undefined,
+      };
+
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        supplier: nonVatSupplier,
+        isSupplierVatPayer: false,
+        lines: [{ description: 'Service', quantity: 1, unitPrice: 100, taxPercent: 0 }],
+        documentAllowanceCharges: [{ chargeIndicator: false, amount: 30, reason: 'Discount' }],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(1);
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">70.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">0.00</cbc:TaxAmount>');
+      expect(subtotals[0]).toContain('<cbc:ID>O</cbc:ID>');
+      expect(subtotals[0]).not.toContain('<cbc:Percent>');
+      expect(subtotals[0]).toContain('<cbc:TaxExemptionReasonCode>VATEX-EU-O</cbc:TaxExemptionReasonCode>');
+    });
+
+    test("category 'O' allowance on a multi-rate invoice sits alongside both rated groups", () => {
+      // Three distinct groups: (S, 21), (S, 11) and (O). Before the fix the two S groups
+      // collapsed and only 2 subtotals were emitted, with VAT 11.00 instead of 32.00.
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Non-taxable rebate', taxCategoryId: 'O', taxPercent: 0 },
+        ],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(3);
+
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">21.00</cbc:TaxAmount>');
+      expect(subtotals[0]).toContain('<cbc:Percent>21.00</cbc:Percent>');
+
+      expect(subtotals[1]).toContain('<cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxAmount currencyID="RON">11.00</cbc:TaxAmount>');
+      expect(subtotals[1]).toContain('<cbc:Percent>11.00</cbc:Percent>');
+
+      // 'O' carries the allowance, no VAT and no Percent.
+      expect(subtotals[2]).toContain('<cbc:TaxableAmount currencyID="RON">-10.00</cbc:TaxableAmount>');
+      expect(subtotals[2]).toContain('<cbc:TaxAmount currencyID="RON">0.00</cbc:TaxAmount>');
+      expect(subtotals[2]).toContain('<cbc:ID>O</cbc:ID>');
+      expect(subtotals[2]).not.toContain('<cbc:Percent>');
+
+      // 21.00 + 11.00 + 0.00 = 32.00 VAT on a 190.00 base.
+      expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="RON">190.00</cbc:TaxExclusiveAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">222.00</cbc:TaxInclusiveAmount>');
+    });
+
+    test('allowance at 21% and charge at 11% each adjust only their own group', () => {
+      // Both directions flow through the same grouping code. Before the fix the two S
+      // groups collapsed and the net −10 + 20 landed on a single 11% base: VAT 12.10.
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Discount', taxCategoryId: 'S', taxPercent: 21 },
+          { chargeIndicator: true, amount: 20, reason: 'Shipping', taxCategoryId: 'S', taxPercent: 11 },
+        ],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(2);
+
+      // 21% group: 100 − 10 = 90 base, 18.90 VAT.
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">90.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">18.90</cbc:TaxAmount>');
+      expect(subtotals[0]).toContain('<cbc:Percent>21.00</cbc:Percent>');
+
+      // 11% group: 100 + 20 = 120 base, 13.20 VAT.
+      expect(subtotals[1]).toContain('<cbc:TaxableAmount currencyID="RON">120.00</cbc:TaxableAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxAmount currencyID="RON">13.20</cbc:TaxAmount>');
+      expect(subtotals[1]).toContain('<cbc:Percent>11.00</cbc:Percent>');
+
+      // 18.90 + 13.20 = 32.10 VAT on a 210.00 base.
+      expect(xml).toContain('<cbc:AllowanceTotalAmount currencyID="RON">10.00</cbc:AllowanceTotalAmount>');
+      expect(xml).toContain('<cbc:ChargeTotalAmount currencyID="RON">20.00</cbc:ChargeTotalAmount>');
+      expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="RON">210.00</cbc:TaxExclusiveAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">242.10</cbc:TaxInclusiveAmount>');
+    });
+
+    test('multi-rate invoice with no document allowances is byte-identical to the v1.5.0 output', () => {
+      // The allowance code path early-returns when there is nothing to apply, so this
+      // invoice must be completely unaffected. The two literals below were captured from
+      // v1.5.0 (pre-fix) output and must survive the change unchanged.
+      const multiRateInvoice: InvoiceInput = {
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+      };
+
+      const xml = builder.generateInvoiceXml(multiRateInvoice);
+
+      const taxTotal = xml.substring(
+        xml.indexOf('<cac:TaxTotal>'),
+        xml.indexOf('</cac:TaxTotal>') + '</cac:TaxTotal>'.length
+      );
+      expect(taxTotal).toBe(
+        `<cac:TaxTotal>
+    <cbc:TaxAmount currencyID="RON">32.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="RON">21.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="RON">11.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>11.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>`
+      );
+
+      const legalMonetaryTotal = xml.substring(
+        xml.indexOf('<cac:LegalMonetaryTotal>'),
+        xml.indexOf('</cac:LegalMonetaryTotal>') + '</cac:LegalMonetaryTotal>'.length
+      );
+      expect(legalMonetaryTotal).toBe(
+        `<cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="RON">200.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="RON">200.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="RON">232.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="RON">232.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>`
+      );
+
+      // An empty documentAllowanceCharges array takes the same early-return path.
+      expect(builder.generateInvoiceXml({ ...multiRateInvoice, documentAllowanceCharges: [] })).toBe(xml);
+    });
+  });
+
   describe('Performance Tests', () => {
     test('should generate XML quickly for simple invoices', () => {
       const start = Date.now();

--- a/sdk/tests/ublBuilder.unit.test.ts
+++ b/sdk/tests/ublBuilder.unit.test.ts
@@ -1942,6 +1942,135 @@ describe('UblBuilder Tests', () => {
     });
   });
 
+  describe('Ambiguous VAT rate on a document-level AllowanceCharge', () => {
+    /**
+     * A tax category does not identify a tax group on its own — 'S' can cover several
+     * rates. When an allowance names a category that several line groups share and does
+     * not say which rate it applies to, the builder must refuse to guess.
+     *
+     * Guessing is worse than failing here: inheriting the wrong rate yields an invoice
+     * that reconciles arithmetically (every total still adds up) while filing the wrong
+     * amount of VAT, which is close to undetectable downstream.
+     */
+
+    const twoRateLines = [
+      { description: 'Standard rated', quantity: 1, unitPrice: 100, taxPercent: 21 },
+      { description: 'Reduced rated', quantity: 1, unitPrice: 100, taxPercent: 11 },
+    ];
+
+    const taxSubtotalsOf = (xml: string): string[] => xml.match(/<cac:TaxSubtotal>[\s\S]*?<\/cac:TaxSubtotal>/g) ?? [];
+
+    test("allowance naming category 'S' without taxPercent throws when lines carry several 'S' rates", () => {
+      // Previously this silently inherited the FIRST matching group's percent (21), so a
+      // discount meant for the 11% base was filed at 21%.
+      const invoiceData: InvoiceInput = {
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [{ chargeIndicator: false, amount: 10, reason: 'Discount', taxCategoryId: 'S' }],
+      };
+
+      // UblBuilder wraps the builder error in AnafValidationError — assert on the
+      // inner message text, as the other throwing tests in this file do.
+      expect(() => builder.generateInvoiceXml(invoiceData)).toThrow(/taxPercent is required/);
+
+      // The message must name the category and both candidate rates — a generic
+      // "ambiguous" string would leave the caller guessing which value to supply.
+      let message = '';
+      try {
+        builder.generateInvoiceXml(invoiceData);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toContain('Allowance/Charge 1');
+      expect(message).toContain('taxPercent');
+      expect(message).toContain("'S'");
+      expect(message).toContain('21%');
+      expect(message).toContain('11%');
+    });
+
+    test('allowance with an explicit taxPercent is unambiguous and lands in that rate group', () => {
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Discount', taxCategoryId: 'S', taxPercent: 11 },
+        ],
+      });
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(2);
+
+      // 21% group untouched, 11% group carries the discount: 100 − 10 = 90 → 9.90 VAT.
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">100.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">21.00</cbc:TaxAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxableAmount currencyID="RON">90.00</cbc:TaxableAmount>');
+      expect(subtotals[1]).toContain('<cbc:TaxAmount currencyID="RON">9.90</cbc:TaxAmount>');
+
+      // 21.00 + 9.90 = 30.90 VAT on a 190.00 base.
+      expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="RON">190.00</cbc:TaxExclusiveAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">220.90</cbc:TaxInclusiveAmount>');
+    });
+
+    test('single-rate invoice still infers the percent from its one matching group', () => {
+      // The common case: exactly one 'S' group, so there is nothing to disambiguate and
+      // omitting taxPercent must keep working.
+      const xml = builder.generateInvoiceXml({
+        ...mockTestData.invoiceData,
+        // mockTestData has a single 100 RON line at 19%.
+        documentAllowanceCharges: [{ chargeIndicator: false, amount: 20, reason: 'Promo', taxCategoryId: 'S' }],
+      });
+
+      const acBlocks = xml.match(/<cac:AllowanceCharge>[\s\S]*?<\/cac:AllowanceCharge>/g) ?? [];
+      expect(acBlocks).toHaveLength(1);
+      expect(acBlocks[0]).toContain('<cbc:ID>S</cbc:ID>');
+      expect(acBlocks[0]).toContain('<cbc:Percent>19.00</cbc:Percent>');
+
+      const subtotals = taxSubtotalsOf(xml);
+      expect(subtotals).toHaveLength(1);
+      expect(subtotals[0]).toContain('<cbc:TaxableAmount currencyID="RON">80.00</cbc:TaxableAmount>');
+      expect(subtotals[0]).toContain('<cbc:TaxAmount currencyID="RON">15.20</cbc:TaxAmount>');
+      expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="RON">95.20</cbc:TaxInclusiveAmount>');
+    });
+
+    test("category 'O' is never rate-ambiguous, on either of the two routes that reach it", () => {
+      // Route 1 — non-VAT supplier. Every allowance is coerced to 'O' before any
+      // category/rate matching happens, so even multi-percent 'O' line groups cannot
+      // trigger the ambiguity error.
+      const nonVatSupplier: Party = { ...mockTestData.invoiceData.supplier, vatNumber: undefined };
+      const nonVatInvoice: InvoiceInput = {
+        ...mockTestData.invoiceData,
+        supplier: nonVatSupplier,
+        isSupplierVatPayer: false,
+        lines: [
+          { description: 'Service A', quantity: 1, unitPrice: 100, taxPercent: 0 },
+          { description: 'Service B', quantity: 1, unitPrice: 50, taxPercent: 19 },
+        ],
+        documentAllowanceCharges: [{ chargeIndicator: false, amount: 30, reason: 'Discount', taxCategoryId: 'O' }],
+      };
+
+      expect(() => builder.generateInvoiceXml(nonVatInvoice)).not.toThrow();
+      const nonVatAcBlock = builder
+        .generateInvoiceXml(nonVatInvoice)
+        .match(/<cac:AllowanceCharge>[\s\S]*?<\/cac:AllowanceCharge>/)![0];
+      expect(nonVatAcBlock).toContain('<cbc:ID>O</cbc:ID>');
+      // BR-O-05: 'O' carries no percent, which is exactly why it cannot be ambiguous.
+      expect(nonVatAcBlock).not.toContain('<cbc:Percent>');
+
+      // Route 2 — VAT supplier, mixed rates, explicit 'O' allowance. Unchanged: it still
+      // gets its own subtotal alongside both rated groups.
+      const mixedInvoice: InvoiceInput = {
+        ...mockTestData.invoiceData,
+        lines: twoRateLines,
+        documentAllowanceCharges: [
+          { chargeIndicator: false, amount: 10, reason: 'Non-taxable rebate', taxCategoryId: 'O', taxPercent: 0 },
+        ],
+      };
+
+      expect(() => builder.generateInvoiceXml(mixedInvoice)).not.toThrow();
+      expect(taxSubtotalsOf(builder.generateInvoiceXml(mixedInvoice))).toHaveLength(3);
+    });
+  });
+
   describe('Performance Tests', () => {
     test('should generate XML quickly for simple invoices', () => {
       const start = Date.now();


### PR DESCRIPTION
Two correctness defects in document-level `AllowanceCharge` handling, both rooted in the same wrong assumption: that a **VAT category identifies a tax group**. In EN 16931 / CIUS-RO the category (BT-118) and the rate (BT-119) are independent — Romania's 21% and 11% rates are both category `S` — so a group is identified by the **(category, rate) pair**.

Two commits, reviewable independently. Recommended release: **patch, `1.5.1`** (no API surface change; both are wrong-output fixes on existing paths). Version bump, tag and publish deliberately left to you.

---

## Defect 1 — mixed-rate VAT breakdown collapses (`7647399`)

`applyAllowancesToTaxGroups` keyed its working map by category alone, so on any invoice mixing 21% and 11% the second group silently overwrote the first and one whole `cac:TaxSubtotal` disappeared.

The function early-returns when there are no document-level allowances, so a multi-rate invoice was **correct until a document discount was added** — at which point the VAT breakdown collapsed. That is not an edge case: a document discount on a mixed-rate invoice is exactly the scenario CIUS-RO mandates, since a single discount must be split into one allowance per distinct rate.

### Reproduction — two 100 RON lines at 21% and 11%, two 10 RON allowances

| | before | after |
|---|---|---|
| `cac:TaxSubtotal` count | **1** | **2** |
| subtotal 1 | — | `TaxableAmount 90.00` / `TaxAmount 18.90` / `S` / `21.00` |
| subtotal 2 | `TaxableAmount 80.00` / `TaxAmount 8.80` / `S` / `11.00` | `TaxableAmount 90.00` / `TaxAmount 9.90` / `S` / `11.00` |
| `TaxTotal/TaxAmount` | **8.80** | **28.80** |
| `TaxInclusiveAmount` | **188.80** | **208.80** |
| `PayableAmount` | 188.80 | 208.80 |

`LineExtensionAmount 200.00`, `AllowanceTotalAmount 20.00` and `TaxExclusiveAmount 180.00` were already correct in both — only the VAT breakdown collapsed, which is what makes it easy to miss.

**User-visible consequence:** an invoice under-declaring VAT by 20.00 RON, filed to ANAF with a breakdown that omits an entire rate band.

### Fix

A `taxGroupKey(categoryId, percent)` helper, used everywhere the map is written or read — including the "no line was rated at this category" synthetic-group fallback, which would otherwise still collide.

Category `O` (not subject to VAT) is deliberately excluded from the percent part of the key: BR-O-05 forbids `cbc:Percent` on it and its `taxAmount` is always 0, so an `O` line group (percent `0`) and a resolved `O` allowance (percent `undefined`) must stay in **one** group rather than split into two spurious subtotals. That choice is pinned by its own test — verified by temporarily substituting a naive `` `${categoryId}-${percent}` `` key, which makes that test fail.

Emission order stays deterministic: line tax groups first, in the order `groupLinesByTax` produced them, then any group created solely by an allowance/charge, in invoice order.

---

## Defect 2 — allowance silently inherits the wrong VAT rate (`c00bf39`)

`resolveAllowanceTaxCategory` matched line groups by category alone too. An allowance carrying `taxCategoryId: 'S'` with **no** `taxPercent` inherited the *first* matching group's percent, so on a mixed 21%/11% invoice a discount meant for the 11% base was silently filed at 21%.

**User-visible consequence:** worse than defect 1, because it is invisible. The invoice reconciles arithmetically — every total adds up — while filing the wrong amount of VAT. Nothing downstream flags it.

### Fix — throw, don't guess

When the named category is carried by several line groups at different rates and no explicit `taxPercent` is supplied:

```
Allowance/Charge 1: taxPercent is required because invoice lines carry several 'S' VAT rates
(21%, 11%) — category and rate are independent, so 'S' alone does not identify a tax group;
set taxPercent to the rate this applies to
```

The message names the category and every candidate rate, so the caller knows which value to supply. Every currently-correct path is preserved:

- a category matching exactly **one** line group still infers that group's percent (the common single-rate case — does not start throwing);
- an explicit `taxPercent` never throws, however many groups share the category;
- category `O` and the `Z`/`O` defaulting paths are untouched.

---

## Tests

10 new cases in `sdk/tests/ublBuilder.unit.test.ts`, all asserting on **emitted XML** rather than on internal helpers.

Defect 1 (6 cases): the reproduction above; an allowance targeting a rate no line carries (synthetic-group fallback); category `O` merging correctly; category `O` alongside two rated groups; an allowance **and** a charge on a multi-rate invoice; and a byte-identity regression guard for a multi-rate invoice with no allowances. **4 of the 6 fail against the previous implementation**, each on `TaxSubtotal` count. The other two are guards by construction — the `O` normalisation guard (verified to fail against a naive composite key) and the byte-identity guard (literals captured from v1.5.0 output precisely so they'd be unchanged).

Defect 2 (4 cases): the ambiguous case — asserting the message actually names `'S'`, `21%` and `11%`, not merely that it throws — plus explicit `taxPercent` landing in the right rate group, single-rate inference still working, and category `O` staying unambiguous on both routes that reach it. **1 of the 4 fails** against the previous implementation (it silently succeeded); the other three are preservation guards.

### Gates

| gate | result |
|---|---|
| `pnpm run verify` (repo's single CI gate) | **EXIT 0** — CLI 367/367, MCP 44/44 |
| `pnpm run test:sdk` | **242/242 passed**, 8 suites (was 238 before these tests) |
| `pnpm run typecheck` | EXIT 0 |
| SDK `lint:check` | EXIT 0 |

`pnpm -r run test` runs the SDK's `test` script, which per `CLAUDE.md` includes the integration suites and needs `.env`: 32 failures across `anafClient.integration.test.ts` and `auth.integration.test.ts`, all `expect(process.env.ANAF_CLIENT_ID).toBeDefined()`-style credential assertions. Baselined against a stashed clean tree — **identical 32 failures**, unrelated to this change.

### Golden files

**None needed regenerating.** `TaxSubtotal` does not appear anywhere in `cli/`, `mcp/` or `docs/`; the repo has no `__snapshots__` directories and no `toMatchSnapshot` usage. The only downstream XML assertion is `cli/tests/services/ublService.test.ts:266` (a `taxCurrencyTaxAmount` passthrough on a single-rate, allowance-free invoice) — untouched and passing.

---

## Suggested CHANGELOG entry (for `1.5.1`)

> **Fixed** — Document-level allowances/charges no longer collapse VAT breakdown groups that share a category but differ in rate (e.g. Romania's 21% and 11%, both category `S`). Tax groups are now keyed by the (category, percent) pair, so a mixed-rate invoice with a document discount emits one `cac:TaxSubtotal` per rate. An allowance that names a category carried by several rates without specifying `taxPercent` now throws instead of silently inheriting the first matching rate.

---

## Known, deliberately out of scope

Both predate this work and are flagged rather than fixed:

1. **Negative `TaxableAmount` from the synthetic-group fallback.** When an allowance targets a rate no line carries, the fallback creates an empty group and subtracts from it, yielding e.g. `-10.00` / `-1.10`. ANAF's schematron will likely reject such a document; the SDK does not guard against it. This fix changes *which* group absorbs the adjustment, not how it is computed — the test at that case pins current behaviour explicitly and says so.
2. **`groupLinesByTax` emitting multiple `O` groups.** If a non-VAT supplier's lines carry a non-zero `taxPercent`, it produces several `O` groups with different percents (and a non-zero `taxAmount` on one), which CIUS-RO forbids. The `O` key normalisation collapses those when allowances are present — behaviourally identical to the old category-only key, so no regression, but the underlying quirk remains.

One minor observation, not touched: on a mixed-rate invoice, an allowance with **no** `taxCategoryId` at all already throws, but with the message `mixed tax categories (S, S)` — accurate about the throw, misleading about the reason. Post-fix, a caller who follows that advice and sets `taxCategoryId: 'S'` now hits the clear defect-2 error instead of silently getting the wrong rate, so the path ends somewhere correct. Happy to tidy the wording in a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VAT handling for invoice allowances and charges when a tax category has multiple rates.
  - Separate subtotals are now preserved for each tax rate.
  - Category `O` adjustments are merged correctly.
  - Ambiguous category-only adjustments now require an explicit tax rate instead of using an arbitrary rate.
- **Tests**
  - Added coverage for multi-rate VAT grouping, rate-specific adjustments, category `O`, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->