### PR TITLE
chore(release): sdk 1.5.1, cli 1.1.1, mcp 1.1.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI for the ANAF e-Factura SDK (anaf-ts-sdk)",
   "license": "MIT",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for the ANAF e-Factura SDK — exposes lookup, UBL, upload, status, download, messages, validate as tools",
   "license": "MIT",
   "repository": {

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-08-06
+
+### Fixed
+
+- Document-level allowances/charges no longer collapse VAT breakdown groups
+  that share a category but differ in rate (e.g. Romania's 21% and 11%, both
+  category `S`). Tax groups are now keyed by the (category, percent) pair, so
+  a mixed-rate invoice with a document discount emits one `cac:TaxSubtotal`
+  per rate. Additionally, an allowance whose category matches several line
+  rates without an explicit `taxPercent` now throws instead of silently
+  inheriting the first rate.
+
 ## [1.5.0] - 2026-08-04
 
 ### Added

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-ts-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Complete TypeScript SDK for Romanian ANAF API -E-Factura, Company checks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump to ship the mixed-rate VAT breakdown fix landed in #16
(`7647399`, `c00bf39`) across all three published packages.

## Releasing (all three, with reasoning)

- **sdk → 1.5.1** (patch). This is the fix itself: `applyAllowancesToTaxGroups`
  now keys VAT groups by `(category, percent)` instead of category alone, and
  `resolveAllowanceTaxCategory` throws on ambiguous rate inference instead of
  silently guessing. No API surface change — strictly a wrong-output fix on
  an existing path.
- **mcp → 1.1.1** (patch). `mcp` resolves `@florinszilagyi/anaf-ts-sdk` via
  `workspace:*`, so its published artifact embeds whatever SDK is current at
  build time. Its current npm artifact (1.1.0) was built against the buggy
  SDK. A republish is the only way its users get the fix.
- **cli → 1.1.1** (patch). `cli` lists the SDK only as a `devDependency`, but
  `cli/src/services/ublService.ts` imports `UblBuilder` directly — the exact
  class containing both buggy functions — and `build:bundle` (esbuild,
  `bundle: true`) inlines it into the published `dist/bin/anaf-cli.cjs`, and
  again into the SEA binaries. So the CLI is affected the same way the MCP
  server is, and needs the same republish.

Nothing is skipped — all three packages consume the fixed code path and all
three currently serve a pre-fix artifact on npm.

## Changes

- `sdk/package.json`: 1.5.0 → 1.5.1
- `cli/package.json`: 1.1.0 → 1.1.1
- `mcp/package.json`: 1.1.0 → 1.1.1
- `sdk/CHANGELOG.md`: adds the 1.5.1 entry

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds unchanged (workspace deps use
      `link:../sdk`, no lockfile diff from the version bumps)
- [x] All three `package.json` files parse and report the intended version
- [ ] After merge: push `sdk-v1.5.1` first, confirm `publish.yaml` succeeds,
      then `cli-v1.1.1` and `mcp-v1.1.1`, and confirm all three on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)