### PR TITLE
feat: download e-Factura invoices as PDF (SDK, CLI, MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ claude mcp add anaf -- npx -y @florinszilagyi/anaf-mcp
 | `anaf_upload_invoice` | Yes | Upload UBL XML to e-Factura (B2B or B2C) |
 | `anaf_invoice_status` | Yes | Poll upload processing status |
 | `anaf_download_invoice` | Yes | Download the processed ZIP archive |
+| `anaf_download_invoice_pdf` | Yes | Download an invoice and save it rendered as a PDF |
 | `anaf_list_messages` | Yes | List sent/received/error messages |
 
 ### Example agentic workflows

--- a/cli/COMMANDS.md
+++ b/cli/COMMANDS.md
@@ -308,15 +308,20 @@ Options:
 
 ### `anaf-cli efactura download`
 
-Download an e-Factura document by id
+Download an e-Factura document by id (ZIP archive, invoice XML, or rendered PDF)
 
 ```
 Usage: anaf-cli efactura download [options]
 
-Download an e-Factura document by id
+Download an e-Factura document by id (ZIP archive, invoice XML, or rendered
+PDF)
 
 Options:
   --download-id <id>     ANAF download id
+  --as <fmt>             download as: zip (default) | xml | pdf
+  --standard <std>       PDF rendering standard (FACT1|FCN), used with --as pdf
+  --no-validation        use the no-validation PDF conversion endpoint, used
+                         with --as pdf
   --out <path>           output file path
   --client-secret-stdin  read OAuth client secret from stdin
   -v, --version          print the CLI version

--- a/cli/COMMANDS.md
+++ b/cli/COMMANDS.md
@@ -319,9 +319,9 @@ PDF)
 Options:
   --download-id <id>     ANAF download id
   --as <fmt>             download as: zip (default) | xml | pdf
-  --standard <std>       PDF rendering standard (FACT1|FCN), used with --as pdf
-  --no-validation        use the no-validation PDF conversion endpoint, used
-                         with --as pdf
+  --standard <std>       PDF rendering standard (FACT1|FCN); requires --as pdf
+  --no-validation        use the no-validation PDF conversion endpoint;
+                         requires --as pdf
   --out <path>           output file path
   --client-secret-stdin  read OAuth client secret from stdin
   -v, --version          print the CLI version

--- a/cli/README.md
+++ b/cli/README.md
@@ -166,6 +166,16 @@ anaf-cli efactura status --upload-id 12345
 anaf-cli efactura download --download-id 67890 [--out response.zip]
 ```
 
+Downloads are ZIP archives by default. `--as` unwraps them for you:
+
+```bash
+anaf-cli efactura download --download-id 67890 --as xml --out invoice.xml
+anaf-cli efactura download --download-id 67890 --as pdf --out invoice.pdf
+```
+
+`--as pdf` renders the downloaded invoice through the ANAF transform service; it
+accepts the same `--standard FACT1|FCN` and `--no-validation` flags as `efactura pdf`.
+
 **Messages:**
 
 ```bash

--- a/cli/README.md
+++ b/cli/README.md
@@ -175,6 +175,8 @@ anaf-cli efactura download --download-id 67890 --as pdf --out invoice.pdf
 
 `--as pdf` renders the downloaded invoice through the ANAF transform service; it
 accepts the same `--standard FACT1|FCN` and `--no-validation` flags as `efactura pdf`.
+Those two flags are rejected with any other `--as` value, so a mistyped format never
+passes silently.
 
 **Messages:**
 

--- a/cli/src/commands/groups/efactura.ts
+++ b/cli/src/commands/groups/efactura.ts
@@ -45,6 +45,9 @@ interface StatusCmdOpts {
 interface DownloadCmdOpts {
   downloadId?: string;
   out?: string;
+  as?: string;
+  standard?: 'FACT1' | 'FCN';
+  validation?: boolean;
   clientSecretStdin?: boolean;
 }
 
@@ -207,6 +210,20 @@ export async function efacturaStatus(deps: CommandDeps, opts: StatusCmdOpts): Pr
   );
 }
 
+const DOWNLOAD_FORMATS = ['zip', 'xml', 'pdf'] as const;
+type DownloadFormat = (typeof DOWNLOAD_FORMATS)[number];
+
+function resolveDownloadFormat(raw?: string): DownloadFormat {
+  if (!raw) return 'zip';
+  const value = raw.toLowerCase();
+  if ((DOWNLOAD_FORMATS as readonly string[]).includes(value)) return value as DownloadFormat;
+  throw new CliError({
+    code: 'BAD_USAGE',
+    message: `Invalid --as "${raw}". Use: ${DOWNLOAD_FORMATS.join(', ')}.`,
+    category: 'user_input',
+  });
+}
+
 export async function efacturaDownload(deps: CommandDeps, opts: DownloadCmdOpts): Promise<void> {
   if (!opts.downloadId) {
     throw new CliError({
@@ -215,7 +232,29 @@ export async function efacturaDownload(deps: CommandDeps, opts: DownloadCmdOpts)
       category: 'user_input',
     });
   }
+  const format = resolveDownloadFormat(opts.as);
   const clientSecret = await resolveClientSecret(deps, opts);
+
+  if (format === 'pdf') {
+    const pdf = await deps.services.efacturaService.downloadPdf({
+      downloadId: opts.downloadId,
+      clientSecret,
+      standard: opts.standard ?? 'FACT1',
+      noValidation: opts.validation === false,
+    });
+    writeBinary(deps.output, pdf, { path: opts.out });
+    return;
+  }
+
+  if (format === 'xml') {
+    const xml = await deps.services.efacturaService.downloadXml({
+      downloadId: opts.downloadId,
+      clientSecret,
+    });
+    writeBinary(deps.output, Buffer.from(xml, 'utf8'), { path: opts.out });
+    return;
+  }
+
   const bytes = await deps.services.efacturaService.download({
     downloadId: opts.downloadId,
     clientSecret,
@@ -388,8 +427,11 @@ export function registerEfactura(parent: Command, deps: CommandDeps): void {
 
   efactura
     .command('download')
-    .description('Download an e-Factura document by id')
+    .description('Download an e-Factura document by id (ZIP archive, invoice XML, or rendered PDF)')
     .option('--download-id <id>', 'ANAF download id')
+    .option('--as <fmt>', 'download as: zip (default) | xml | pdf')
+    .option('--standard <std>', 'PDF rendering standard (FACT1|FCN), used with --as pdf')
+    .option('--no-validation', 'use the no-validation PDF conversion endpoint, used with --as pdf')
     .option('--out <path>', 'output file path')
     .option('--client-secret-stdin', 'read OAuth client secret from stdin')
     .action((opts: DownloadCmdOpts) => efacturaDownload(deps, opts));

--- a/cli/src/commands/groups/efactura.ts
+++ b/cli/src/commands/groups/efactura.ts
@@ -46,7 +46,7 @@ interface DownloadCmdOpts {
   downloadId?: string;
   out?: string;
   as?: string;
-  standard?: 'FACT1' | 'FCN';
+  standard?: string;
   validation?: boolean;
   clientSecretStdin?: boolean;
 }
@@ -63,7 +63,7 @@ interface MessagesCmdOpts {
 interface ValidateCmdOpts {
   xml?: string;
   stdin?: boolean;
-  standard?: 'FACT1' | 'FCN';
+  standard?: string;
   clientSecretStdin?: boolean;
 }
 
@@ -76,7 +76,7 @@ interface ValidateSignatureCmdOpts {
 interface PdfCmdOpts {
   xml?: string;
   stdin?: boolean;
-  standard?: 'FACT1' | 'FCN';
+  standard?: string;
   out?: string;
   validation?: boolean;
   clientSecretStdin?: boolean;
@@ -213,6 +213,9 @@ export async function efacturaStatus(deps: CommandDeps, opts: StatusCmdOpts): Pr
 const DOWNLOAD_FORMATS = ['zip', 'xml', 'pdf'] as const;
 type DownloadFormat = (typeof DOWNLOAD_FORMATS)[number];
 
+const DOCUMENT_STANDARDS = ['FACT1', 'FCN'] as const;
+type DocumentStandard = (typeof DOCUMENT_STANDARDS)[number];
+
 function resolveDownloadFormat(raw?: string): DownloadFormat {
   if (!raw) return 'zip';
   const value = raw.toLowerCase();
@@ -220,6 +223,21 @@ function resolveDownloadFormat(raw?: string): DownloadFormat {
   throw new CliError({
     code: 'BAD_USAGE',
     message: `Invalid --as "${raw}". Use: ${DOWNLOAD_FORMATS.join(', ')}.`,
+    category: 'user_input',
+  });
+}
+
+/**
+ * Validate `--standard` locally so a typo fails before any network call
+ * rather than after a document has already been fetched.
+ */
+function resolveStandard(raw?: string): DocumentStandard {
+  if (!raw) return 'FACT1';
+  const value = raw.toUpperCase();
+  if ((DOCUMENT_STANDARDS as readonly string[]).includes(value)) return value as DocumentStandard;
+  throw new CliError({
+    code: 'BAD_USAGE',
+    message: `Invalid --standard "${raw}". Use: ${DOCUMENT_STANDARDS.join(', ')}.`,
     category: 'user_input',
   });
 }
@@ -233,14 +251,27 @@ export async function efacturaDownload(deps: CommandDeps, opts: DownloadCmdOpts)
     });
   }
   const format = resolveDownloadFormat(opts.as);
+  const standard = resolveStandard(opts.standard);
+  const noValidation = opts.validation === false;
+
+  // Rendering options only mean something on the PDF path — accepting them
+  // silently elsewhere would hide a mistyped --as from the user.
+  if (format !== 'pdf' && (opts.standard !== undefined || noValidation)) {
+    throw new CliError({
+      code: 'BAD_USAGE',
+      message: `--standard and --no-validation apply to "--as pdf" only (got "--as ${format}").`,
+      category: 'user_input',
+    });
+  }
+
   const clientSecret = await resolveClientSecret(deps, opts);
 
   if (format === 'pdf') {
     const pdf = await deps.services.efacturaService.downloadPdf({
       downloadId: opts.downloadId,
       clientSecret,
-      standard: opts.standard ?? 'FACT1',
-      noValidation: opts.validation === false,
+      standard,
+      noValidation,
     });
     writeBinary(deps.output, pdf, { path: opts.out });
     return;
@@ -318,12 +349,13 @@ export async function efacturaMessages(deps: CommandDeps, opts: MessagesCmdOpts)
 }
 
 export async function efacturaValidate(deps: CommandDeps, opts: ValidateCmdOpts): Promise<void> {
+  const standard = resolveStandard(opts.standard);
   const xml = await resolveXmlInput(opts);
   const clientSecret = await resolveClientSecret(deps, opts);
   const result = await deps.services.efacturaService.validateXml({
     clientSecret,
     xml,
-    standard: opts.standard ?? 'FACT1',
+    standard,
   });
   renderSuccess(deps.output, result, (d) =>
     kv([
@@ -382,13 +414,14 @@ export async function efacturaValidateSignature(deps: CommandDeps, opts: Validat
 }
 
 export async function efacturaPdf(deps: CommandDeps, opts: PdfCmdOpts): Promise<void> {
+  const standard = resolveStandard(opts.standard);
   const xml = await resolveXmlInput(opts);
   const clientSecret = await resolveClientSecret(deps, opts);
   const noValidation = opts.validation === false;
   const bytes = await deps.services.efacturaService.convertToPdf({
     clientSecret,
     xml,
-    standard: opts.standard ?? 'FACT1',
+    standard,
     noValidation,
   });
   writeBinary(deps.output, bytes, { path: opts.out });
@@ -430,8 +463,8 @@ export function registerEfactura(parent: Command, deps: CommandDeps): void {
     .description('Download an e-Factura document by id (ZIP archive, invoice XML, or rendered PDF)')
     .option('--download-id <id>', 'ANAF download id')
     .option('--as <fmt>', 'download as: zip (default) | xml | pdf')
-    .option('--standard <std>', 'PDF rendering standard (FACT1|FCN), used with --as pdf')
-    .option('--no-validation', 'use the no-validation PDF conversion endpoint, used with --as pdf')
+    .option('--standard <std>', 'PDF rendering standard (FACT1|FCN); requires --as pdf')
+    .option('--no-validation', 'use the no-validation PDF conversion endpoint; requires --as pdf')
     .option('--out <path>', 'output file path')
     .option('--client-secret-stdin', 'read OAuth client secret from stdin')
     .action((opts: DownloadCmdOpts) => efacturaDownload(deps, opts));

--- a/cli/src/services/efacturaService.ts
+++ b/cli/src/services/efacturaService.ts
@@ -40,6 +40,7 @@ export interface EfacturaClientLike {
   uploadB2CDocument(xml: string, options?: UploadOptions): Promise<UploadResponse>;
   getUploadStatus(uploadId: string): Promise<StatusResponse>;
   downloadDocument(downloadId: string): Promise<Buffer>;
+  downloadDocumentXml(downloadId: string): Promise<string>;
   getMessages(params: { zile: number; filtru?: MessageFilter }): Promise<ListMessagesResponse>;
   getMessagesPaginated(params: {
     startTime: number;
@@ -93,6 +94,11 @@ export interface StatusArgs {
 export interface DownloadArgs {
   downloadId: string;
   clientSecret: string;
+}
+
+export interface DownloadPdfArgs extends DownloadArgs {
+  standard?: 'FACT1' | 'FCN';
+  noValidation?: boolean;
 }
 
 export interface MessagesArgs {
@@ -210,6 +216,32 @@ export class EfacturaService {
       } catch (cause) {
         throw wrapAnafError('DOWNLOAD_FAILED', 'Failed to download document', cause);
       }
+    });
+  }
+
+  /**
+   * Download a document and return the invoice XML unwrapped from ANAF's ZIP.
+   */
+  async downloadXml(args: DownloadArgs): Promise<string> {
+    return this.withClient(args.clientSecret, async (client) => {
+      try {
+        return await client.downloadDocumentXml(args.downloadId);
+      } catch (cause) {
+        throw wrapAnafError('DOWNLOAD_FAILED', 'Failed to download document', cause);
+      }
+    });
+  }
+
+  /**
+   * Download a document and render it as a PDF through the ANAF transform service.
+   */
+  async downloadPdf(args: DownloadPdfArgs): Promise<Buffer> {
+    const xml = await this.downloadXml({ downloadId: args.downloadId, clientSecret: args.clientSecret });
+    return this.convertToPdf({
+      clientSecret: args.clientSecret,
+      xml,
+      standard: args.standard,
+      noValidation: args.noValidation,
     });
   }
 

--- a/cli/src/services/efacturaService.ts
+++ b/cli/src/services/efacturaService.ts
@@ -234,14 +234,26 @@ export class EfacturaService {
 
   /**
    * Download a document and render it as a PDF through the ANAF transform service.
+   *
+   * Both calls share one token manager, so a stored token that needs refreshing
+   * is refreshed once for the pair rather than once per leg.
    */
   async downloadPdf(args: DownloadPdfArgs): Promise<Buffer> {
-    const xml = await this.downloadXml({ downloadId: args.downloadId, clientSecret: args.clientSecret });
-    return this.convertToPdf({
-      clientSecret: args.clientSecret,
-      xml,
-      standard: args.standard,
-      noValidation: args.noValidation,
+    return this.withClientAndTools(args.clientSecret, async (client, tools) => {
+      let xml: string;
+      try {
+        xml = await client.downloadDocumentXml(args.downloadId);
+      } catch (cause) {
+        throw wrapAnafError('DOWNLOAD_FAILED', 'Failed to download document', cause);
+      }
+
+      try {
+        return args.noValidation
+          ? await tools.convertXmlToPdfNoValidation(xml, args.standard ?? 'FACT1')
+          : await tools.convertXmlToPdf(xml, args.standard ?? 'FACT1');
+      } catch (cause) {
+        throw wrapAnafError('PDF_CONVERSION_FAILED', 'Failed to convert XML to PDF', cause);
+      }
     });
   }
 
@@ -380,6 +392,38 @@ export class EfacturaService {
 
     try {
       return await fn(client);
+    } finally {
+      this.persistRotation(tokenManager, originalRefreshToken);
+    }
+  }
+
+  /**
+   * Run an operation that needs both clients within a single token cycle.
+   *
+   * Building the two clients off one token manager keeps an expiring access
+   * token to one refresh (and one rotation) for the whole command.
+   */
+  private async withClientAndTools<T>(
+    clientSecret: string,
+    fn: (client: EfacturaClientLike, tools: EfacturaToolsClientLike) => Promise<T>
+  ): Promise<T> {
+    const { cui, env } = this.resolveActiveCompany();
+    const credential = this.credentialService.get();
+    const authenticator = this.buildAuthenticator(credential.clientId, clientSecret, credential.redirectUri);
+    const { tokenManager, originalRefreshToken } = this.selectTokenManager(authenticator);
+
+    const client = this.clientFactory({
+      vatNumber: cui.replace(/^RO/i, ''),
+      testMode: env === 'test',
+      tokenManager,
+    });
+    const tools = this.toolsFactory({
+      testMode: env === 'test',
+      tokenManager,
+    });
+
+    try {
+      return await fn(client, tools);
     } finally {
       this.persistRotation(tokenManager, originalRefreshToken);
     }

--- a/cli/src/services/index.ts
+++ b/cli/src/services/index.ts
@@ -15,6 +15,7 @@ export {
   type UploadArgs,
   type StatusArgs,
   type DownloadArgs,
+  type DownloadPdfArgs,
   type MessagesArgs,
   type ValidateArgs,
   type ValidateSignatureArgs,

--- a/cli/tests/commands/groups/efactura.test.ts
+++ b/cli/tests/commands/groups/efactura.test.ts
@@ -336,6 +336,67 @@ describe('efacturaDownload', () => {
     }
   });
 
+  it('rejects --standard before making any network call', async () => {
+    const h = harness();
+    try {
+      await expect(
+        efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', as: 'pdf', standard: 'FACT9' })
+      ).rejects.toBeInstanceOf(CliError);
+      expect(h.efacturaService.downloadPdfCalls).toHaveLength(0);
+      expect(h.efacturaService.downloadXmlCalls).toHaveLength(0);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('normalizes a lowercase --standard instead of passing it through', async () => {
+    const h = harness();
+    try {
+      await efacturaDownload(
+        { output: h.text, services: h.services },
+        { downloadId: 'd-1', as: 'pdf', standard: 'fcn' }
+      );
+      expect(h.efacturaService.downloadPdfCalls[0]).toMatchObject({ standard: 'FCN' });
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('rejects --standard when --as is not pdf', async () => {
+    const h = harness();
+    try {
+      await expect(
+        efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', as: 'xml', standard: 'FCN' })
+      ).rejects.toBeInstanceOf(CliError);
+      expect(h.efacturaService.downloadXmlCalls).toHaveLength(0);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('rejects --no-validation when --as is not pdf', async () => {
+    const h = harness();
+    try {
+      await expect(
+        efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', validation: false })
+      ).rejects.toBeInstanceOf(CliError);
+      expect(h.efacturaService.downloadCalls).toHaveLength(0);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('leaves the default zip path untouched when no new flags are given', async () => {
+    const h = harness();
+    try {
+      await efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', validation: true });
+      expect(h.efacturaService.downloadCalls).toHaveLength(1);
+      expect(h.stdout.bytes.toString('utf8')).toBe('ZIPDATA');
+    } finally {
+      h.restore();
+    }
+  });
+
   it('throws BAD_USAGE on an unknown --as value', async () => {
     const h = harness();
     try {
@@ -524,6 +585,18 @@ describe('efacturaValidateSignature', () => {
 });
 
 describe('efacturaPdf', () => {
+  it('rejects an invalid --standard before reading input', async () => {
+    const h = harness();
+    try {
+      await expect(
+        efacturaPdf({ output: h.text, services: h.services }, { xml: '/nonexistent.xml', standard: 'nope' })
+      ).rejects.toBeInstanceOf(CliError);
+      expect(h.efacturaService.pdfCalls).toHaveLength(0);
+    } finally {
+      h.restore();
+    }
+  });
+
   it('writes PDF bytes to --out and emits confirmation to stderr', async () => {
     const h = harness();
     try {

--- a/cli/tests/commands/groups/efactura.test.ts
+++ b/cli/tests/commands/groups/efactura.test.ts
@@ -19,6 +19,7 @@ import type {
   UploadArgs,
   StatusArgs,
   DownloadArgs,
+  DownloadPdfArgs,
   MessagesArgs,
   ValidateArgs,
   ValidateSignatureArgs,
@@ -39,6 +40,8 @@ class StubEfacturaService {
   uploadCalls: UploadArgs[] = [];
   statusCalls: StatusArgs[] = [];
   downloadCalls: DownloadArgs[] = [];
+  downloadXmlCalls: DownloadArgs[] = [];
+  downloadPdfCalls: DownloadPdfArgs[] = [];
   messagesCalls: MessagesArgs[] = [];
   validateCalls: ValidateArgs[] = [];
   validateSignatureCalls: ValidateSignatureArgs[] = [];
@@ -57,6 +60,14 @@ class StubEfacturaService {
   async download(args: DownloadArgs) {
     this.downloadCalls.push(args);
     return Buffer.from('ZIPDATA');
+  }
+  async downloadXml(args: DownloadArgs) {
+    this.downloadXmlCalls.push(args);
+    return '<Invoice/>';
+  }
+  async downloadPdf(args: DownloadPdfArgs) {
+    this.downloadPdfCalls.push(args);
+    return Buffer.from('%PDF-DOWNLOADED');
   }
   messagesResult: unknown = { mesaje: [{ id: 'm-1' }] };
   async getMessages(args: MessagesArgs) {
@@ -273,6 +284,65 @@ describe('efacturaDownload', () => {
     const h = harness();
     try {
       await expect(efacturaDownload({ output: h.text, services: h.services }, {})).rejects.toBeInstanceOf(CliError);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('writes the invoice XML with --as xml', async () => {
+    const h = harness();
+    try {
+      await efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', as: 'xml' });
+      expect(h.efacturaService.downloadXmlCalls[0]).toMatchObject({ downloadId: 'd-1' });
+      expect(h.efacturaService.downloadCalls).toHaveLength(0);
+      expect(h.stdout.bytes.toString('utf8')).toBe('<Invoice/>');
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('writes a rendered PDF with --as pdf', async () => {
+    const h = harness();
+    try {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-cli-efdlpdf-'));
+      const outPath = path.join(tmp, 'invoice.pdf');
+      await efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', as: 'pdf', out: outPath });
+      expect(h.efacturaService.downloadPdfCalls[0]).toMatchObject({
+        downloadId: 'd-1',
+        standard: 'FACT1',
+        noValidation: false,
+      });
+      expect(fs.readFileSync(outPath, 'utf8')).toBe('%PDF-DOWNLOADED');
+      fs.rmSync(tmp, { recursive: true });
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('passes --standard and --no-validation through to the PDF conversion', async () => {
+    const h = harness();
+    try {
+      await efacturaDownload(
+        { output: h.text, services: h.services },
+        { downloadId: 'd-2', as: 'PDF', standard: 'FCN', validation: false }
+      );
+      expect(h.efacturaService.downloadPdfCalls[0]).toMatchObject({
+        downloadId: 'd-2',
+        standard: 'FCN',
+        noValidation: true,
+      });
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('throws BAD_USAGE on an unknown --as value', async () => {
+    const h = harness();
+    try {
+      await expect(
+        efacturaDownload({ output: h.text, services: h.services }, { downloadId: 'd-1', as: 'docx' })
+      ).rejects.toBeInstanceOf(CliError);
+      expect(h.efacturaService.downloadCalls).toHaveLength(0);
     } finally {
       h.restore();
     }

--- a/cli/tests/services/efacturaService.test.ts
+++ b/cli/tests/services/efacturaService.test.ts
@@ -57,6 +57,7 @@ class FakeEfacturaClient {
     })
   );
   downloadDocument = jest.fn(async (): Promise<Buffer> => Buffer.from('fake-zip'));
+  downloadDocumentXml = jest.fn(async (): Promise<string> => '<Invoice><ID>FCT-1</ID></Invoice>');
   getMessages = jest.fn(async (): Promise<ListMessagesResponse> => ({ mesaje: [] }) as unknown as ListMessagesResponse);
   getMessagesPaginated = jest.fn(
     async (): Promise<PaginatedListMessagesResponse> => ({ mesaje: [] }) as unknown as PaginatedListMessagesResponse
@@ -454,6 +455,70 @@ describe('EfacturaService.download', () => {
     }
     expect(err).toBeInstanceOf(CliError);
     expect((err as CliError).code).toBe('DOWNLOAD_FAILED');
+  });
+});
+
+describe('EfacturaService.downloadXml', () => {
+  it('returns the invoice XML unwrapped by the SDK client', async () => {
+    const h = harness();
+    setupState(h);
+    const xml = await h.service.downloadXml({ downloadId: 'download-1', clientSecret: 's' });
+    expect(h.fakeClient.downloadDocumentXml).toHaveBeenCalledWith('download-1');
+    expect(xml).toBe('<Invoice><ID>FCT-1</ID></Invoice>');
+  });
+
+  it('wraps SDK failure as DOWNLOAD_FAILED', async () => {
+    const h = harness();
+    setupState(h);
+    h.fakeClient.downloadDocumentXml.mockRejectedValueOnce(new Error('bad archive'));
+    let err: unknown;
+    try {
+      await h.service.downloadXml({ downloadId: 'download-1', clientSecret: 's' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).code).toBe('DOWNLOAD_FAILED');
+  });
+});
+
+describe('EfacturaService.downloadPdf', () => {
+  it('downloads the XML and renders it through the transform service', async () => {
+    const h = harness();
+    setupState(h);
+    const pdf = await h.service.downloadPdf({ downloadId: 'download-1', clientSecret: 's' });
+    expect(h.fakeClient.downloadDocumentXml).toHaveBeenCalledWith('download-1');
+    expect(h.fakeTools.convertXmlToPdf).toHaveBeenCalledWith('<Invoice><ID>FCT-1</ID></Invoice>', 'FACT1');
+    expect(h.fakeTools.convertXmlToPdfNoValidation).not.toHaveBeenCalled();
+    expect(pdf.toString('utf8')).toBe('%PDF-1.4');
+  });
+
+  it('uses the no-validation endpoint and the requested standard', async () => {
+    const h = harness();
+    setupState(h);
+    const pdf = await h.service.downloadPdf({
+      downloadId: 'download-1',
+      clientSecret: 's',
+      standard: 'FCN',
+      noValidation: true,
+    });
+    expect(h.fakeTools.convertXmlToPdfNoValidation).toHaveBeenCalledWith('<Invoice><ID>FCT-1</ID></Invoice>', 'FCN');
+    expect(h.fakeTools.convertXmlToPdf).not.toHaveBeenCalled();
+    expect(pdf.toString('utf8')).toBe('%PDF-1.4-noval');
+  });
+
+  it('wraps conversion failure as PDF_CONVERSION_FAILED', async () => {
+    const h = harness();
+    setupState(h);
+    h.fakeTools.convertXmlToPdf.mockRejectedValueOnce(new Error('transform refused'));
+    let err: unknown;
+    try {
+      await h.service.downloadPdf({ downloadId: 'download-1', clientSecret: 's' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).code).toBe('PDF_CONVERSION_FAILED');
   });
 });
 

--- a/cli/tests/services/efacturaService.test.ts
+++ b/cli/tests/services/efacturaService.test.ts
@@ -520,6 +520,42 @@ describe('EfacturaService.downloadPdf', () => {
     expect(err).toBeInstanceOf(CliError);
     expect((err as CliError).code).toBe('PDF_CONVERSION_FAILED');
   });
+
+  it('wraps download failure as DOWNLOAD_FAILED without attempting conversion', async () => {
+    const h = harness();
+    setupState(h);
+    h.fakeClient.downloadDocumentXml.mockRejectedValueOnce(new Error('gone'));
+    let err: unknown;
+    try {
+      await h.service.downloadPdf({ downloadId: 'download-1', clientSecret: 's' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).code).toBe('DOWNLOAD_FAILED');
+    expect(h.fakeTools.convertXmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the token once for the whole command, not once per leg', async () => {
+    // Both legs share one token manager: an expiring token costs one refresh
+    // and one rotation, not two.
+    let factoryCalls = 0;
+    const h = harness({
+      tokenManagerFactory: ({ refreshToken }) => {
+        factoryCalls += 1;
+        const tm = new FakeTokenManager(refreshToken);
+        tm.rotate = true;
+        void tm.getValidAccessToken(); // the stub clients never ask, so rotate here
+        return tm;
+      },
+    });
+    setupState(h);
+
+    await h.service.downloadPdf({ downloadId: 'download-1', clientSecret: 's' });
+
+    expect(factoryCalls).toBe(1);
+    expect(h.tokenStore.read('_default')?.refreshToken).toBe('rt-rotated');
+  });
 });
 
 describe('EfacturaService.getMessages', () => {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -26,6 +26,7 @@ The MCP server stores state at the same XDG paths as `anaf-cli`, so credentials 
 | `anaf_upload_invoice` | Yes | Upload UBL XML to e-Factura (B2B or B2C) |
 | `anaf_invoice_status` | Yes | Poll upload processing status |
 | `anaf_download_invoice` | Yes | Download the processed ZIP archive |
+| `anaf_download_invoice_pdf` | Yes | Download an invoice and save it rendered as a PDF |
 | `anaf_list_messages` | Yes | List sent/received/error messages |
 
 ## Authentication

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -16,8 +16,11 @@ import { UPLOAD_INVOICE_TOOL_DEFINITION, handleUploadInvoice, uploadInvoiceInput
 import { INVOICE_STATUS_TOOL_DEFINITION, handleInvoiceStatus, invoiceStatusInputSchema } from './tools/status.js';
 import {
   DOWNLOAD_INVOICE_TOOL_DEFINITION,
+  DOWNLOAD_INVOICE_PDF_TOOL_DEFINITION,
   handleDownloadInvoice,
+  handleDownloadInvoicePdf,
   downloadInvoiceInputSchema,
+  downloadInvoicePdfInputSchema,
 } from './tools/download.js';
 import { LIST_MESSAGES_TOOL_DEFINITION, handleListMessages, listMessagesInputSchema } from './tools/messages.js';
 import {
@@ -48,6 +51,7 @@ const TOOL_DEFINITIONS = [
   UPLOAD_INVOICE_TOOL_DEFINITION,
   INVOICE_STATUS_TOOL_DEFINITION,
   DOWNLOAD_INVOICE_TOOL_DEFINITION,
+  DOWNLOAD_INVOICE_PDF_TOOL_DEFINITION,
   LIST_MESSAGES_TOOL_DEFINITION,
 ];
 
@@ -115,6 +119,10 @@ export async function handleToolCall(name: string, args: unknown): Promise<AnyTo
       case DOWNLOAD_INVOICE_TOOL_DEFINITION.name: {
         const input = downloadInvoiceInputSchema.parse(args);
         return runAuthedTool((s) => handleDownloadInvoice(input, { efactura: s.efactura }));
+      }
+      case DOWNLOAD_INVOICE_PDF_TOOL_DEFINITION.name: {
+        const input = downloadInvoicePdfInputSchema.parse(args);
+        return runAuthedTool((s) => handleDownloadInvoicePdf(input, { efactura: s.efactura, tools: s.tools }));
       }
       case LIST_MESSAGES_TOOL_DEFINITION.name: {
         const input = listMessagesInputSchema.parse(args);

--- a/mcp/src/tools/download.ts
+++ b/mcp/src/tools/download.ts
@@ -5,6 +5,35 @@ import type { EfacturaClient, EfacturaToolsClient } from '@florinszilagyi/anaf-t
 import { McpToolError, formatToolError } from '../errors.js';
 import type { ToolResult } from './types.js';
 
+/**
+ * Write bytes to `outputPath`, reporting a local filesystem failure as such
+ * instead of folding it into whatever ANAF call preceded it.
+ */
+function writeOutput(outputPath: string, bytes: Buffer): string {
+  const abs = path.resolve(outputPath);
+  try {
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, bytes);
+  } catch (err) {
+    throw new McpToolError({
+      code: 'WRITE_FAILED',
+      message: `Could not write to output_path "${abs}": ${err instanceof Error ? err.message : String(err)}`,
+      category: 'user_input',
+    });
+  }
+  return abs;
+}
+
+/** Wrap a non-McpToolError as `code`; errors already typed are passed through. */
+function asToolError(err: unknown, code: string): McpToolError {
+  if (err instanceof McpToolError) return err;
+  return new McpToolError({
+    code,
+    message: err instanceof Error ? err.message : String(err),
+    category: 'anaf_api',
+  });
+}
+
 export const downloadInvoiceInputSchema = z.object({
   download_id: z.string().min(1).describe('The idDescarcare returned from anaf_invoice_status (when stare=ok)'),
   output_path: z.string().min(1).describe('Absolute or relative path where the ZIP file should be written'),
@@ -19,9 +48,7 @@ export interface DownloadDeps {
 export async function handleDownloadInvoice(input: DownloadInvoiceInput, deps: DownloadDeps): Promise<ToolResult> {
   try {
     const buf = await deps.efactura.downloadDocument(input.download_id);
-    const abs = path.resolve(input.output_path);
-    fs.mkdirSync(path.dirname(abs), { recursive: true });
-    fs.writeFileSync(abs, buf);
+    const abs = writeOutput(input.output_path, buf);
     return {
       content: [
         {
@@ -31,13 +58,8 @@ export async function handleDownloadInvoice(input: DownloadInvoiceInput, deps: D
       ],
     };
   } catch (err) {
-    const wrapped = new McpToolError({
-      code: 'DOWNLOAD_FAILED',
-      message: err instanceof Error ? err.message : String(err),
-      category: 'anaf_api',
-    });
     return {
-      content: [{ type: 'text', text: formatToolError(wrapped) }],
+      content: [{ type: 'text', text: formatToolError(asToolError(err, 'DOWNLOAD_FAILED')) }],
       isError: true,
     };
   }
@@ -77,15 +99,13 @@ export async function handleDownloadInvoicePdf(
   deps: DownloadPdfDeps
 ): Promise<ToolResult> {
   try {
-    const parsed = downloadInvoicePdfInputSchema.parse(input);
+    const parsed = parseInput(input);
     const xml = await deps.efactura.downloadDocumentXml(parsed.download_id);
     const pdf = parsed.no_validation
       ? await deps.tools.convertXmlToPdfNoValidation(xml, parsed.standard)
       : await deps.tools.convertXmlToPdf(xml, parsed.standard);
 
-    const abs = path.resolve(parsed.output_path);
-    fs.mkdirSync(path.dirname(abs), { recursive: true });
-    fs.writeFileSync(abs, pdf);
+    const abs = writeOutput(parsed.output_path, pdf);
     return {
       content: [
         {
@@ -99,16 +119,24 @@ export async function handleDownloadInvoicePdf(
       ],
     };
   } catch (err) {
-    const wrapped = new McpToolError({
-      code: 'DOWNLOAD_PDF_FAILED',
-      message: err instanceof Error ? err.message : String(err),
-      category: 'anaf_api',
-    });
     return {
-      content: [{ type: 'text', text: formatToolError(wrapped) }],
+      content: [{ type: 'text', text: formatToolError(asToolError(err, 'DOWNLOAD_PDF_FAILED')) }],
       isError: true,
     };
   }
+}
+
+/** Re-validate defensively: the handler is exported and callable on its own. */
+function parseInput(input: DownloadInvoicePdfInput): z.infer<typeof downloadInvoicePdfInputSchema> {
+  const result = downloadInvoicePdfInputSchema.safeParse(input);
+  if (!result.success) {
+    throw new McpToolError({
+      code: 'INVALID_INPUT',
+      message: result.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; '),
+      category: 'user_input',
+    });
+  }
+  return result.data;
 }
 
 export const DOWNLOAD_INVOICE_PDF_TOOL_DEFINITION = {

--- a/mcp/src/tools/download.ts
+++ b/mcp/src/tools/download.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
-import type { EfacturaClient } from '@florinszilagyi/anaf-ts-sdk';
+import type { EfacturaClient, EfacturaToolsClient } from '@florinszilagyi/anaf-ts-sdk';
 import { McpToolError, formatToolError } from '../errors.js';
 import type { ToolResult } from './types.js';
 
@@ -48,4 +48,72 @@ export const DOWNLOAD_INVOICE_TOOL_DEFINITION = {
   description:
     'Download the processed invoice ZIP archive for a completed upload. Writes bytes to output_path and returns { path, bytes, downloadId }. Requires ANAF auth.',
   inputSchema: downloadInvoiceInputSchema,
+};
+
+export const downloadInvoicePdfInputSchema = z.object({
+  download_id: z.string().min(1).describe('The idDescarcare returned from anaf_invoice_status (when stare=ok)'),
+  output_path: z.string().min(1).describe('Absolute or relative path where the PDF file should be written'),
+  standard: z
+    .enum(['FACT1', 'FCN'])
+    .describe('Rendering standard: FACT1 for invoices (default), FCN for credit notes')
+    .optional()
+    .default('FACT1'),
+  no_validation: z
+    .boolean()
+    .describe('Skip ANAF schema validation before rendering — use when a valid invoice is rejected by the validator')
+    .optional()
+    .default(false),
+});
+
+export type DownloadInvoicePdfInput = z.input<typeof downloadInvoicePdfInputSchema>;
+
+export interface DownloadPdfDeps {
+  efactura: Pick<EfacturaClient, 'downloadDocumentXml'>;
+  tools: Pick<EfacturaToolsClient, 'convertXmlToPdf' | 'convertXmlToPdfNoValidation'>;
+}
+
+export async function handleDownloadInvoicePdf(
+  input: DownloadInvoicePdfInput,
+  deps: DownloadPdfDeps
+): Promise<ToolResult> {
+  try {
+    const parsed = downloadInvoicePdfInputSchema.parse(input);
+    const xml = await deps.efactura.downloadDocumentXml(parsed.download_id);
+    const pdf = parsed.no_validation
+      ? await deps.tools.convertXmlToPdfNoValidation(xml, parsed.standard)
+      : await deps.tools.convertXmlToPdf(xml, parsed.standard);
+
+    const abs = path.resolve(parsed.output_path);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, pdf);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            { path: abs, bytes: pdf.length, downloadId: parsed.download_id, standard: parsed.standard },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (err) {
+    const wrapped = new McpToolError({
+      code: 'DOWNLOAD_PDF_FAILED',
+      message: err instanceof Error ? err.message : String(err),
+      category: 'anaf_api',
+    });
+    return {
+      content: [{ type: 'text', text: formatToolError(wrapped) }],
+      isError: true,
+    };
+  }
+}
+
+export const DOWNLOAD_INVOICE_PDF_TOOL_DEFINITION = {
+  name: 'anaf_download_invoice_pdf',
+  description:
+    'Download an invoice and save it as a PDF. Fetches the ZIP for download_id, unwraps the invoice XML, renders it through the ANAF transform service, and writes the PDF to output_path. Returns { path, bytes, downloadId, standard }. Requires ANAF auth.',
+  inputSchema: downloadInvoicePdfInputSchema,
 };

--- a/mcp/tests/smoke.test.ts
+++ b/mcp/tests/smoke.test.ts
@@ -15,7 +15,7 @@ describe('MCP server smoke test', () => {
     }
   });
 
-  it('lists all 10 tools in response to tools/list', async () => {
+  it('lists all 11 tools in response to tools/list', async () => {
     const child = spawn('node', [SERVER_PATH], {
       env: {
         ...process.env,
@@ -50,6 +50,7 @@ describe('MCP server smoke test', () => {
     expect(output).toContain('anaf_upload_invoice');
     expect(output).toContain('anaf_invoice_status');
     expect(output).toContain('anaf_download_invoice');
+    expect(output).toContain('anaf_download_invoice_pdf');
     expect(output).toContain('anaf_list_messages');
   }, 10000);
 });

--- a/mcp/tests/tools/download.test.ts
+++ b/mcp/tests/tools/download.test.ts
@@ -29,6 +29,23 @@ describe('handleDownloadInvoice', () => {
     }
   });
 
+  it('reports a local write failure as WRITE_FAILED', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-mcp-dl-'));
+    try {
+      const mockClient = {
+        downloadDocument: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('zip')),
+      };
+      const result = await handleDownloadInvoice(
+        { download_id: 'dl-1', output_path: tmpDir },
+        { efactura: mockClient as any }
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('WRITE_FAILED');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('wraps SDK errors', async () => {
     const mockClient = {
       downloadDocument: jest.fn<() => Promise<never>>().mockRejectedValue(new Error('404')),
@@ -116,6 +133,44 @@ describe('handleDownloadInvoicePdf', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/DOWNLOAD_PDF_FAILED|no such invoice/);
     expect(mockTools.convertXmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('reports a local write failure as WRITE_FAILED, not as an ANAF failure', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-mcp-pdf-'));
+    try {
+      const mockClient = {
+        downloadDocumentXml: jest.fn<() => Promise<string>>().mockResolvedValue('<Invoice/>'),
+      };
+      const mockTools = {
+        convertXmlToPdf: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('%PDF-1.4')),
+        convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>(),
+      };
+
+      // A directory is not a writable target for the PDF.
+      const result = await handleDownloadInvoicePdf(
+        { download_id: 'dl-42', output_path: tmpDir },
+        { efactura: mockClient as any, tools: mockTools as any }
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('WRITE_FAILED');
+      expect(result.content[0].text).not.toContain('DOWNLOAD_PDF_FAILED');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports invalid input as INVALID_INPUT when called directly', async () => {
+    const result = await handleDownloadInvoicePdf({ download_id: '', output_path: '' } as any, {
+      efactura: { downloadDocumentXml: jest.fn<() => Promise<string>>() } as any,
+      tools: {
+        convertXmlToPdf: jest.fn<() => Promise<Buffer>>(),
+        convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>(),
+      } as any,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('INVALID_INPUT');
   });
 
   it('wraps conversion errors', async () => {

--- a/mcp/tests/tools/download.test.ts
+++ b/mcp/tests/tools/download.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { handleDownloadInvoice } from '../../src/tools/download.js';
+import { handleDownloadInvoice, handleDownloadInvoicePdf } from '../../src/tools/download.js';
 
 describe('handleDownloadInvoice', () => {
   it('writes ZIP bytes to the given output_path and returns metadata', async () => {
@@ -39,5 +39,107 @@ describe('handleDownloadInvoice', () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/DOWNLOAD_FAILED|404/);
+  });
+});
+
+describe('handleDownloadInvoicePdf', () => {
+  it('renders the downloaded invoice XML to a PDF at output_path', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-mcp-pdf-'));
+    const outPath = path.join(tmpDir, 'nested', 'invoice.pdf');
+    try {
+      const pdf = Buffer.from('%PDF-1.4 fake');
+      const mockClient = {
+        downloadDocumentXml: jest.fn<() => Promise<string>>().mockResolvedValue('<Invoice/>'),
+      };
+      const mockTools = {
+        convertXmlToPdf: jest.fn<() => Promise<Buffer>>().mockResolvedValue(pdf),
+        convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('nope')),
+      };
+
+      const result = await handleDownloadInvoicePdf(
+        { download_id: 'dl-42', output_path: outPath },
+        { efactura: mockClient as any, tools: mockTools as any }
+      );
+
+      expect(mockClient.downloadDocumentXml).toHaveBeenCalledWith('dl-42');
+      expect(mockTools.convertXmlToPdf).toHaveBeenCalledWith('<Invoice/>', 'FACT1');
+      expect(mockTools.convertXmlToPdfNoValidation).not.toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+      expect(fs.readFileSync(outPath).equals(pdf)).toBe(true);
+      expect(result.content[0].text).toContain(outPath);
+      expect(result.content[0].text).toContain('FACT1');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honours standard and no_validation', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-mcp-pdf-'));
+    const outPath = path.join(tmpDir, 'credit-note.pdf');
+    try {
+      const mockClient = {
+        downloadDocumentXml: jest.fn<() => Promise<string>>().mockResolvedValue('<CreditNote/>'),
+      };
+      const mockTools = {
+        convertXmlToPdf: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('nope')),
+        convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('%PDF-1.4 cn')),
+      };
+
+      const result = await handleDownloadInvoicePdf(
+        { download_id: 'dl-7', output_path: outPath, standard: 'FCN', no_validation: true },
+        { efactura: mockClient as any, tools: mockTools as any }
+      );
+
+      expect(mockTools.convertXmlToPdfNoValidation).toHaveBeenCalledWith('<CreditNote/>', 'FCN');
+      expect(mockTools.convertXmlToPdf).not.toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+      expect(fs.readFileSync(outPath).toString('utf8')).toBe('%PDF-1.4 cn');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('wraps download errors', async () => {
+    const mockClient = {
+      downloadDocumentXml: jest.fn<() => Promise<never>>().mockRejectedValue(new Error('no such invoice')),
+    };
+    const mockTools = {
+      convertXmlToPdf: jest.fn<() => Promise<Buffer>>(),
+      convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>(),
+    };
+
+    const result = await handleDownloadInvoicePdf(
+      { download_id: 'bogus', output_path: '/tmp/should-not-exist.pdf' },
+      { efactura: mockClient as any, tools: mockTools as any }
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/DOWNLOAD_PDF_FAILED|no such invoice/);
+    expect(mockTools.convertXmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('wraps conversion errors', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anaf-mcp-pdf-'));
+    const outPath = path.join(tmpDir, 'invoice.pdf');
+    try {
+      const mockClient = {
+        downloadDocumentXml: jest.fn<() => Promise<string>>().mockResolvedValue('<Invoice/>'),
+      };
+      const mockTools = {
+        convertXmlToPdf: jest.fn<() => Promise<never>>().mockRejectedValue(new Error('transform refused')),
+        convertXmlToPdfNoValidation: jest.fn<() => Promise<Buffer>>(),
+      };
+
+      const result = await handleDownloadInvoicePdf(
+        { download_id: 'dl-42', output_path: outPath },
+        { efactura: mockClient as any, tools: mockTools as any }
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/DOWNLOAD_PDF_FAILED|transform refused/);
+      expect(fs.existsSync(outPath)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/anaf-mcp/skills/anaf-invoice.md
+++ b/plugins/anaf-mcp/skills/anaf-invoice.md
@@ -64,10 +64,22 @@ Call `anaf_invoice_status` with the upload index. Retry every 30-60 seconds unti
 
 ## Step 5 — Download (optional)
 
-Call `anaf_download_invoice` with the upload index to get the signed ZIP archive from ANAF.
+Downloads are keyed by the `idDescarcare` that `anaf_invoice_status` returns once the status
+is `ok` — not by the upload index. Both download tools also require an `output_path` to write to.
 
-For a human-readable copy, call `anaf_download_invoice_pdf` instead — it unwraps the archive
-and writes the invoice rendered as a PDF (pass `standard: "FCN"` for credit notes).
+```json
+{ "download_id": "4013735587", "output_path": "./invoices/FCT-1.zip" }
+```
+
+Call `anaf_download_invoice` with that to get the signed ZIP archive from ANAF. For a
+human-readable copy, call `anaf_download_invoice_pdf` instead — it unwraps the archive and
+writes the invoice rendered as a PDF:
+
+```json
+{ "download_id": "4013735587", "output_path": "./invoices/FCT-1.pdf", "standard": "FACT1" }
+```
+
+Pass `standard: "FCN"` for credit notes.
 
 ## Common invoice patterns
 

--- a/plugins/anaf-mcp/skills/anaf-invoice.md
+++ b/plugins/anaf-mcp/skills/anaf-invoice.md
@@ -66,6 +66,9 @@ Call `anaf_invoice_status` with the upload index. Retry every 30-60 seconds unti
 
 Call `anaf_download_invoice` with the upload index to get the signed ZIP archive from ANAF.
 
+For a human-readable copy, call `anaf_download_invoice_pdf` instead — it unwraps the archive
+and writes the invoice rendered as a PDF (pass `standard: "FCN"` for credit notes).
+
 ## Common invoice patterns
 
 **B2B (business to business):** Default. Buyer CUI required.

--- a/plugins/anaf-mcp/skills/anaf-invoice.md
+++ b/plugins/anaf-mcp/skills/anaf-invoice.md
@@ -94,6 +94,6 @@ Pass `standard: "FCN"` for credit notes.
 ## Tips
 
 - Always validate before uploading — ANAF rejects invalid XML without a clear error at upload time
-- Save the `uploadIndex` — you need it to check status and download
+- Save the `uploadIndex` — you need it to check status; downloads use the `idDescarcare` that `anaf_invoice_status` returns
 - ANAF processing usually completes in under 5 minutes
 - Test with `ANAF_ENV=test` first before going live with `prod`

--- a/plugins/anaf-mcp/skills/anaf-messages.md
+++ b/plugins/anaf-mcp/skills/anaf-messages.md
@@ -34,8 +34,18 @@ Call `anaf_list_messages` with:
 
 ## Downloading a received invoice
 
-If you see a message with an `id`, call `anaf_download_invoice` with that ID to get the signed ZIP,
-or `anaf_download_invoice_pdf` to save the same invoice rendered as a PDF.
+A message `id` is a download id — pass it as `download_id`, along with the `output_path` to
+write to. `anaf_download_invoice` saves the signed ZIP:
+
+```json
+{ "download_id": "3041234567", "output_path": "./invoices/received-3041234567.zip" }
+```
+
+`anaf_download_invoice_pdf` saves the same invoice rendered as a PDF:
+
+```json
+{ "download_id": "3041234567", "output_path": "./invoices/received-3041234567.pdf" }
+```
 
 ## Checking a specific upload
 

--- a/plugins/anaf-mcp/skills/anaf-messages.md
+++ b/plugins/anaf-mcp/skills/anaf-messages.md
@@ -44,8 +44,11 @@ write to. `anaf_download_invoice` saves the signed ZIP:
 `anaf_download_invoice_pdf` saves the same invoice rendered as a PDF:
 
 ```json
-{ "download_id": "3041234567", "output_path": "./invoices/received-3041234567.pdf" }
+{ "download_id": "3041234567", "output_path": "./invoices/received-3041234567.pdf", "standard": "FACT1" }
 ```
+
+Use `"standard": "FCN"` when the document is a credit note — a received message can be
+either, so check before rendering.
 
 ## Checking a specific upload
 

--- a/plugins/anaf-mcp/skills/anaf-messages.md
+++ b/plugins/anaf-mcp/skills/anaf-messages.md
@@ -34,7 +34,8 @@ Call `anaf_list_messages` with:
 
 ## Downloading a received invoice
 
-If you see a message with an `id`, call `anaf_download_invoice` with that ID to get the signed ZIP.
+If you see a message with an `id`, call `anaf_download_invoice` with that ID to get the signed ZIP,
+or `anaf_download_invoice_pdf` to save the same invoice rendered as a PDF.
 
 ## Checking a specific upload
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -65,9 +65,15 @@ const uploadResult = await client.uploadDocument(tokens.access_token, xmlContent
 // Check upload status
 const status = await client.getUploadStatus(tokens.access_token, uploadResult.index_incarcare);
 
-// Download processed document
+// Download processed document (ZIP archive: invoice + detached signature)
 if (status.id_descarcare) {
   const result = await client.downloadDocument(tokens.access_token, status.id_descarcare);
+
+  // Or unwrap the archive and get the invoice XML directly
+  const invoiceXml = await client.downloadDocumentXml(status.id_descarcare);
+
+  // …which is what you need to render the invoice as a PDF
+  const pdf = await client.convertXmlToPdf(invoiceXml, 'FACT1');
 }
 
 // List recent messages

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -46,47 +46,54 @@ console.log('Access token:', tokens.access_token);
 const newTokens = await auth.refreshAccessToken(tokens.refresh_token);
 ```
 
-### 2. AnafClient - API Operations
+### 2. AnafEfacturaClient - API Operations
+
+The client is constructed once with a refresh token and resolves access tokens
+itself, so no call takes a token argument.
 
 ```typescript
-import { AnafClient } from '@florinszilagyi/anaf-ts-sdk';
+import { AnafEfacturaClient } from '@florinszilagyi/anaf-ts-sdk';
 
-const client = new AnafClient({
-  vatNumber: 'RO12345678',
-  testMode: true, // Use test environment
-});
+const client = new AnafEfacturaClient(
+  {
+    vatNumber: 'RO12345678',
+    testMode: true, // Use test environment
+    refreshToken: tokens.refresh_token,
+  },
+  auth // the AnafAuthenticator from step 1
+);
 
 // Upload a document
-const uploadResult = await client.uploadDocument(tokens.access_token, xmlContent, {
+const uploadResult = await client.uploadDocument(xmlContent, {
   standard: 'UBL',
   executare: true,
 });
 
 // Check upload status
-const status = await client.getUploadStatus(tokens.access_token, uploadResult.index_incarcare);
+const status = await client.getUploadStatus(uploadResult.indexIncarcare);
 
 // Download processed document (ZIP archive: invoice + detached signature)
-if (status.id_descarcare) {
-  const result = await client.downloadDocument(tokens.access_token, status.id_descarcare);
+if (status.idDescarcare) {
+  const result = await client.downloadDocument(status.idDescarcare);
 
   // Or unwrap the archive and get the invoice XML directly
-  const invoiceXml = await client.downloadDocumentXml(status.id_descarcare);
+  const invoiceXml = await client.downloadDocumentXml(status.idDescarcare);
 
   // …which is what you need to render the invoice as a PDF
   const pdf = await client.convertXmlToPdf(invoiceXml, 'FACT1');
 }
 
 // List recent messages
-const messages = await client.getMessages(tokens.access_token, {
+const messages = await client.getMessages({
   zile: 7, // Last 7 days
   filtru: 'E', // Only errors
 });
 
 // Validate XML
-const validation = await client.validateXml(tokens.access_token, xmlContent, 'FACT1');
+const validation = await client.validateXml(xmlContent, 'FACT1');
 
 // Convert XML to PDF
-const pdfBuffer = await client.convertXmlToPdf(tokens.access_token, xmlContent, 'FACT1');
+const pdfBuffer = await client.convertXmlToPdf(xmlContent, 'FACT1');
 ```
 
 ### 3. UblBuilder - UBL XML Generation

--- a/sdk/src/AnafClient.ts
+++ b/sdk/src/AnafClient.ts
@@ -91,6 +91,10 @@ export class AnafEfacturaClient {
     return this.efacturaClient.downloadDocument(downloadId);
   }
 
+  public downloadDocumentXml(downloadId: string): Promise<string> {
+    return this.efacturaClient.downloadDocumentXml(downloadId);
+  }
+
   public getMessagesPaginated(params: PaginatedMessagesParams): Promise<PaginatedListMessagesResponse> {
     return this.efacturaClient.getMessagesPaginated(params);
   }

--- a/sdk/src/EfacturaClient.ts
+++ b/sdk/src/EfacturaClient.ts
@@ -37,6 +37,7 @@ import {
   extractErrorMessage,
 } from './utils/xmlParser';
 import { isValidDaysParameter } from './utils/dateUtils';
+import { extractInvoiceXml } from './utils/zipReader';
 import { HttpClient } from './utils/httpClient';
 import { handleApiError } from './utils/errorHandler';
 import { tryCatch } from './tryCatch';
@@ -196,6 +197,20 @@ export class EfacturaClient {
     }
 
     return data;
+  }
+
+  /**
+   * Download a document and return the invoice XML it contains.
+   *
+   * ANAF serves downloads as a ZIP holding the invoice plus a detached
+   * signature; this unwraps the archive and returns the invoice document.
+   *
+   * @param downloadId - The `idDescarcare` from a status response or message list
+   * @returns The invoice XML as a UTF-8 string
+   */
+  async downloadDocumentXml(downloadId: string): Promise<string> {
+    const archive = await this.downloadDocument(downloadId);
+    return extractInvoiceXml(archive);
   }
 
   // ==========================================================================

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -55,6 +55,10 @@ export * from './errors';
 // UBL Builder
 export * from './ubl';
 
+// ZIP utilities (e-Factura downloads are ZIP archives)
+export { readZipEntries, extractInvoiceXml } from './utils/zipReader';
+export type { ZipEntry } from './utils/zipReader';
+
 // Message utilities
 export { parseDetalii } from './utils/messageParser';
 export { enrichMessagesWithCompanyData } from './utils/messageEnricher';

--- a/sdk/src/utils/zipReader.ts
+++ b/sdk/src/utils/zipReader.ts
@@ -18,14 +18,28 @@ const MAX_COMMENT_SIZE = 0xffff;
 const METHOD_STORED = 0;
 const METHOD_DEFLATE = 8;
 
+/** General purpose bit 0: the entry is encrypted. */
+const FLAG_ENCRYPTED = 0x0001;
+
+/** Value a 32-bit ZIP field carries when the real value lives in a ZIP64 record. */
+const ZIP64_MARKER_32 = 0xffffffff;
+/** Value a 16-bit ZIP field carries when the real value lives in a ZIP64 record. */
+const ZIP64_MARKER_16 = 0xffff;
+
 /**
  * Locate the End of Central Directory record by scanning backwards from the
  * end of the buffer (the record is last, but may be followed by a comment).
+ *
+ * The signature alone is not enough: those four bytes can occur inside an
+ * archive comment. A match only counts when its declared comment length
+ * accounts for exactly the remaining bytes.
  */
 function findEndOfCentralDirectory(buffer: Buffer): number {
   const minOffset = Math.max(0, buffer.length - EOCD_MIN_SIZE - MAX_COMMENT_SIZE);
   for (let offset = buffer.length - EOCD_MIN_SIZE; offset >= minOffset; offset--) {
-    if (buffer.readUInt32LE(offset) === EOCD_SIGNATURE) {
+    if (buffer.readUInt32LE(offset) !== EOCD_SIGNATURE) continue;
+    const commentLength = buffer.readUInt16LE(offset + 20);
+    if (offset + EOCD_MIN_SIZE + commentLength === buffer.length) {
       return offset;
     }
   }
@@ -55,8 +69,9 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
   }
 
   const entryCount = buffer.readUInt16LE(eocd + 10);
+  const centralDirSize = buffer.readUInt32LE(eocd + 12);
   const centralDirOffset = buffer.readUInt32LE(eocd + 16);
-  if (centralDirOffset === 0xffffffff) {
+  if (centralDirOffset === ZIP64_MARKER_32 || centralDirSize === ZIP64_MARKER_32 || entryCount === ZIP64_MARKER_16) {
     throw new AnafValidationError('Unsupported ZIP archive: ZIP64 format');
   }
 
@@ -68,6 +83,7 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
       throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
     }
 
+    const flags = buffer.readUInt16LE(offset + 8);
     const compressionMethod = buffer.readUInt16LE(offset + 10);
     const compressedSize = buffer.readUInt32LE(offset + 20);
     const uncompressedSize = buffer.readUInt32LE(offset + 24);
@@ -75,13 +91,28 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
     const extraLength = buffer.readUInt16LE(offset + 30);
     const commentLength = buffer.readUInt16LE(offset + 32);
     const localHeaderOffset = buffer.readUInt32LE(offset + 42);
-    const name = buffer.subarray(offset + 46, offset + 46 + nameLength).toString('utf8');
 
-    offset += 46 + nameLength + extraLength + commentLength;
+    // subarray() clamps instead of throwing, so an oversized length field would
+    // otherwise yield a silently truncated name rather than a parse failure.
+    const headerEnd = offset + 46 + nameLength + extraLength + commentLength;
+    if (headerEnd > buffer.length) {
+      throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
+    }
+
+    const name = buffer.subarray(offset + 46, offset + 46 + nameLength).toString('utf8');
+    offset = headerEnd;
 
     // Directory entries carry no payload.
     if (name.endsWith('/')) {
       continue;
+    }
+
+    if ((flags & FLAG_ENCRYPTED) !== 0) {
+      throw new AnafValidationError(`Unsupported ZIP archive: "${name}" is encrypted`);
+    }
+
+    if (compressedSize === ZIP64_MARKER_32 || uncompressedSize === ZIP64_MARKER_32) {
+      throw new AnafValidationError('Unsupported ZIP archive: ZIP64 format');
     }
 
     if (localHeaderOffset + 30 > buffer.length || buffer.readUInt32LE(localHeaderOffset) !== LOCAL_HEADER_SIGNATURE) {
@@ -126,12 +157,18 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
   return entries;
 }
 
+/** Root elements of the documents e-Factura archives carry. */
+const INVOICE_ROOT_ELEMENTS = ['Invoice', 'CreditNote'];
+
 /**
  * Extract the invoice XML from an e-Factura download archive.
  *
  * ANAF returns a ZIP containing the invoice XML plus a detached signature
- * (`semnatura_*.xml`). This picks the invoice document and returns it as a
- * UTF-8 string with any byte order mark stripped.
+ * (`semnatura_*.xml`), and can add further documents alongside them. Selection
+ * is therefore by content — the entry whose root element is `Invoice` or
+ * `CreditNote` wins — falling back to the first non-signature XML when no
+ * entry declares a recognised root. The result is decoded as UTF-8 with any
+ * byte order mark stripped.
  *
  * @param zipBuffer - The archive returned by `EfacturaClient.downloadDocument`
  * @returns The invoice XML document
@@ -147,9 +184,34 @@ export function extractInvoiceXml(zipBuffer: Buffer): string {
     );
   }
 
-  const invoice = xmlEntries.find((e) => !basename(e.name).toLowerCase().startsWith('semnatura')) ?? xmlEntries[0];
+  const candidates = xmlEntries.map((entry) => ({ entry, text: decodeXml(entry.data) }));
+  const byRootElement = candidates.find((c) => INVOICE_ROOT_ELEMENTS.includes(rootElementName(c.text)));
+  if (byRootElement) {
+    return byRootElement.text;
+  }
 
-  return invoice.data.toString('utf8').replace(/^\uFEFF/, '');
+  const nonSignature = candidates.find((c) => !basename(c.entry.name).toLowerCase().startsWith('semnatura'));
+  return (nonSignature ?? candidates[0]).text;
+}
+
+function decodeXml(data: Buffer): string {
+  return data.toString('utf8').replace(/^\uFEFF/, '');
+}
+
+/**
+ * Read the local name of a document's root element, ignoring any namespace
+ * prefix, XML declaration, comments and processing instructions.
+ */
+function rootElementName(xml: string): string {
+  const match = /<(?!\?|!)([^\s/>]+)/.exec(stripXmlComments(xml));
+  if (!match) return '';
+  const [, tag] = match;
+  const colon = tag.lastIndexOf(':');
+  return colon === -1 ? tag : tag.slice(colon + 1);
+}
+
+function stripXmlComments(xml: string): string {
+  return xml.replace(/<!--[\s\S]*?-->/g, '');
 }
 
 function basename(name: string): string {

--- a/sdk/src/utils/zipReader.ts
+++ b/sdk/src/utils/zipReader.ts
@@ -1,0 +1,158 @@
+import { inflateRawSync } from 'node:zlib';
+import { AnafValidationError } from '../errors';
+
+/** A single decompressed file entry from a ZIP archive. */
+export interface ZipEntry {
+  /** Entry path as stored in the archive. */
+  name: string;
+  /** Decompressed bytes. */
+  data: Buffer;
+}
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_HEADER_SIGNATURE = 0x02014b50;
+const LOCAL_HEADER_SIGNATURE = 0x04034b50;
+const EOCD_MIN_SIZE = 22;
+const MAX_COMMENT_SIZE = 0xffff;
+
+const METHOD_STORED = 0;
+const METHOD_DEFLATE = 8;
+
+/**
+ * Locate the End of Central Directory record by scanning backwards from the
+ * end of the buffer (the record is last, but may be followed by a comment).
+ */
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const minOffset = Math.max(0, buffer.length - EOCD_MIN_SIZE - MAX_COMMENT_SIZE);
+  for (let offset = buffer.length - EOCD_MIN_SIZE; offset >= minOffset; offset--) {
+    if (buffer.readUInt32LE(offset) === EOCD_SIGNATURE) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Read all file entries from an in-memory ZIP archive.
+ *
+ * Supports the two compression methods ANAF uses (stored and deflate). No
+ * external dependency — the central directory is parsed directly and deflate
+ * streams are inflated with `node:zlib`.
+ *
+ * @param buffer - Raw ZIP archive bytes
+ * @returns Every file entry in the archive, directories excluded
+ * @throws {AnafValidationError} If the archive is malformed or uses an
+ *   unsupported compression method
+ */
+export function readZipEntries(buffer: Buffer): ZipEntry[] {
+  if (!buffer || buffer.length < EOCD_MIN_SIZE) {
+    throw new AnafValidationError('Invalid ZIP archive: too small');
+  }
+
+  const eocd = findEndOfCentralDirectory(buffer);
+  if (eocd < 0) {
+    throw new AnafValidationError('Invalid ZIP archive: end of central directory not found');
+  }
+
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  const centralDirOffset = buffer.readUInt32LE(eocd + 16);
+  if (centralDirOffset === 0xffffffff) {
+    throw new AnafValidationError('Unsupported ZIP archive: ZIP64 format');
+  }
+
+  const entries: ZipEntry[] = [];
+  let offset = centralDirOffset;
+
+  for (let i = 0; i < entryCount; i++) {
+    if (offset + 46 > buffer.length || buffer.readUInt32LE(offset) !== CENTRAL_HEADER_SIGNATURE) {
+      throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
+    }
+
+    const compressionMethod = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const uncompressedSize = buffer.readUInt32LE(offset + 24);
+    const nameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const name = buffer.subarray(offset + 46, offset + 46 + nameLength).toString('utf8');
+
+    offset += 46 + nameLength + extraLength + commentLength;
+
+    // Directory entries carry no payload.
+    if (name.endsWith('/')) {
+      continue;
+    }
+
+    if (localHeaderOffset + 30 > buffer.length || buffer.readUInt32LE(localHeaderOffset) !== LOCAL_HEADER_SIGNATURE) {
+      throw new AnafValidationError(`Invalid ZIP archive: corrupt local header for "${name}"`);
+    }
+
+    const localNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength;
+    const dataEnd = dataStart + compressedSize;
+
+    if (dataEnd > buffer.length) {
+      throw new AnafValidationError(`Invalid ZIP archive: truncated data for "${name}"`);
+    }
+
+    const raw = buffer.subarray(dataStart, dataEnd);
+    let data: Buffer;
+
+    if (compressionMethod === METHOD_STORED) {
+      data = Buffer.from(raw);
+    } else if (compressionMethod === METHOD_DEFLATE) {
+      try {
+        data = inflateRawSync(raw);
+      } catch (cause) {
+        throw new AnafValidationError(
+          `Invalid ZIP archive: failed to inflate "${name}" (${cause instanceof Error ? cause.message : String(cause)})`
+        );
+      }
+    } else {
+      throw new AnafValidationError(
+        `Unsupported ZIP compression method ${compressionMethod} for "${name}" (expected stored or deflate)`
+      );
+    }
+
+    if (uncompressedSize !== 0 && data.length !== uncompressedSize) {
+      throw new AnafValidationError(`Invalid ZIP archive: size mismatch for "${name}"`);
+    }
+
+    entries.push({ name, data });
+  }
+
+  return entries;
+}
+
+/**
+ * Extract the invoice XML from an e-Factura download archive.
+ *
+ * ANAF returns a ZIP containing the invoice XML plus a detached signature
+ * (`semnatura_*.xml`). This picks the invoice document and returns it as a
+ * UTF-8 string with any byte order mark stripped.
+ *
+ * @param zipBuffer - The archive returned by `EfacturaClient.downloadDocument`
+ * @returns The invoice XML document
+ * @throws {AnafValidationError} If the archive holds no invoice XML
+ */
+export function extractInvoiceXml(zipBuffer: Buffer): string {
+  const entries = readZipEntries(zipBuffer);
+  const xmlEntries = entries.filter((e) => e.name.toLowerCase().endsWith('.xml'));
+
+  if (xmlEntries.length === 0) {
+    throw new AnafValidationError(
+      `No XML document found in the downloaded archive (entries: ${entries.map((e) => e.name).join(', ') || 'none'})`
+    );
+  }
+
+  const invoice = xmlEntries.find((e) => !basename(e.name).toLowerCase().startsWith('semnatura')) ?? xmlEntries[0];
+
+  return invoice.data.toString('utf8').replace(/^\uFEFF/, '');
+}
+
+function basename(name: string): string {
+  const slash = name.lastIndexOf('/');
+  return slash === -1 ? name : name.slice(slash + 1);
+}

--- a/sdk/src/utils/zipReader.ts
+++ b/sdk/src/utils/zipReader.ts
@@ -18,6 +18,13 @@ const MAX_COMMENT_SIZE = 0xffff;
 const METHOD_STORED = 0;
 const METHOD_DEFLATE = 8;
 
+/**
+ * Ceiling on a single decompressed entry. e-Factura invoices are a few KB;
+ * this only exists so a malformed or hostile archive cannot make us allocate
+ * unbounded memory before the size check runs.
+ */
+const MAX_ENTRY_BYTES = 64 * 1024 * 1024;
+
 /** General purpose bit 0: the entry is encrypted. */
 const FLAG_ENCRYPTED = 0x0001;
 
@@ -75,6 +82,13 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
     throw new AnafValidationError('Unsupported ZIP archive: ZIP64 format');
   }
 
+  // Entries must live inside the directory the EOCD declares, not merely
+  // inside the buffer — otherwise a record could run on into the EOCD itself.
+  const centralDirEnd = centralDirOffset + centralDirSize;
+  if (centralDirOffset > eocd || centralDirEnd > eocd) {
+    throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
+  }
+
   const entries: ZipEntry[] = [];
   let offset = centralDirOffset;
 
@@ -95,7 +109,7 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
     // subarray() clamps instead of throwing, so an oversized length field would
     // otherwise yield a silently truncated name rather than a parse failure.
     const headerEnd = offset + 46 + nameLength + extraLength + commentLength;
-    if (headerEnd > buffer.length) {
+    if (headerEnd > centralDirEnd) {
       throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
     }
 
@@ -134,11 +148,18 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
     if (compressionMethod === METHOD_STORED) {
       data = Buffer.from(raw);
     } else if (compressionMethod === METHOD_DEFLATE) {
+      if (uncompressedSize > MAX_ENTRY_BYTES) {
+        throw new AnafValidationError(`ZIP entry "${name}" exceeds the ${MAX_ENTRY_BYTES}-byte limit`);
+      }
       try {
-        data = inflateRawSync(raw);
+        // The declared size can lie, so cap the inflate itself as well.
+        data = inflateRawSync(raw, { maxOutputLength: MAX_ENTRY_BYTES });
       } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
         throw new AnafValidationError(
-          `Invalid ZIP archive: failed to inflate "${name}" (${cause instanceof Error ? cause.message : String(cause)})`
+          isOutputTooLarge(cause)
+            ? `ZIP entry "${name}" exceeds the ${MAX_ENTRY_BYTES}-byte limit`
+            : `Invalid ZIP archive: failed to inflate "${name}" (${message})`
         );
       }
     } else {
@@ -154,7 +175,16 @@ export function readZipEntries(buffer: Buffer): ZipEntry[] {
     entries.push({ name, data });
   }
 
+  if (offset !== centralDirEnd) {
+    throw new AnafValidationError('Invalid ZIP archive: corrupt central directory');
+  }
+
   return entries;
+}
+
+/** True when zlib refused to inflate because the output hit `maxOutputLength`. */
+function isOutputTooLarge(cause: unknown): boolean {
+  return (cause as { code?: string } | undefined)?.code === 'ERR_BUFFER_TOO_LARGE';
 }
 
 /** Root elements of the documents e-Factura archives carry. */

--- a/sdk/tests/anafClient.unit.test.ts
+++ b/sdk/tests/anafClient.unit.test.ts
@@ -3,6 +3,7 @@ import { AnafValidationError, AnafApiError, AnafAuthenticationError } from '../s
 import { UploadOptions, PaginatedMessagesParams, ListMessagesParams, MessageFilter } from '../src/types';
 import { AnafAuthenticator } from '../src/AnafAuthenticator';
 import { mockTestData } from './testUtils';
+import { buildZip } from './zipFixtures';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -349,6 +350,41 @@ describe('AnafEfacturaClient Unit Tests', () => {
 
       expect(Buffer.isBuffer(result)).toBe(true);
       expect(result.toString('utf8')).toBe(mockDownloadContent);
+    });
+
+    test('should unwrap the invoice XML from the downloaded archive', async () => {
+      const invoiceXml = '<?xml version="1.0" encoding="UTF-8"?><Invoice><ID>FCT-1</ID></Invoice>';
+      const zipBytes = buildZip([
+        { name: 'semnatura_4013735587.xml', content: '<Signature/>' },
+        { name: '4013735587.xml', content: invoiceXml },
+      ]);
+      (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => (name === 'content-type' ? 'application/zip' : null),
+        },
+        arrayBuffer: () =>
+          Promise.resolve(zipBytes.buffer.slice(zipBytes.byteOffset, zipBytes.byteOffset + zipBytes.byteLength)),
+      });
+
+      const result = await client.downloadDocumentXml(mockDownloadId);
+
+      expect(result).toBe(invoiceXml);
+    });
+
+    test('should reject a downloaded archive that is not a ZIP', async () => {
+      const bytes = Buffer.from('ANAF returned an error page');
+      (fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => (name === 'content-type' ? 'application/zip' : null),
+        },
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+      });
+
+      await expect(client.downloadDocumentXml(mockDownloadId)).rejects.toThrow(AnafValidationError);
     });
 
     test('should download with application/octet-stream content-type', async () => {

--- a/sdk/tests/zipFixtures.ts
+++ b/sdk/tests/zipFixtures.ts
@@ -1,11 +1,35 @@
-import { deflateRawSync, crc32 } from 'node:zlib';
+import { deflateRawSync } from 'node:zlib';
+
+// zlib.crc32 only exists on Node >= 20.15, below the versions this SDK
+// supports, so the checksum is computed here instead.
+const METHOD_DEFLATE = 8;
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let bit = 0; bit < 8; bit++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
 
 /** One file to place in a test archive. */
 export interface ZipInput {
   name: string;
   content: string | Buffer;
-  /** 0 = stored, 8 = deflate. Defaults to deflate. */
-  method?: 0 | 8;
+  /** 0 = stored, 8 = deflate. Any other value exercises the reject path. Defaults to deflate. */
+  method?: number;
   /** General purpose bit flag, e.g. 0x0001 to mark the entry encrypted. */
   flags?: number;
 }
@@ -31,7 +55,7 @@ export function buildZip(files: ZipInput[], options: ZipOptions = {}): Buffer {
     const flags = file.flags ?? 0;
     const nameBytes = Buffer.from(file.name, 'utf8');
     const raw = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content, 'utf8');
-    const compressed = method === 0 ? raw : deflateRawSync(raw);
+    const compressed = method === METHOD_DEFLATE ? deflateRawSync(raw) : raw;
 
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);

--- a/sdk/tests/zipFixtures.ts
+++ b/sdk/tests/zipFixtures.ts
@@ -1,0 +1,78 @@
+import { deflateRawSync, crc32 } from 'node:zlib';
+
+/** One file to place in a test archive. */
+export interface ZipInput {
+  name: string;
+  content: string | Buffer;
+  /** 0 = stored, 8 = deflate. Defaults to deflate. */
+  method?: 0 | 8;
+}
+
+/**
+ * Minimal ZIP writer for tests — produces archives shaped like the ones ANAF
+ * returns, so the reader can be exercised without checking binary fixtures
+ * into git.
+ */
+export function buildZip(files: ZipInput[]): Buffer {
+  const localChunks: Buffer[] = [];
+  const centralChunks: Buffer[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const method = file.method ?? 8;
+    const nameBytes = Buffer.from(file.name, 'utf8');
+    const raw = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content, 'utf8');
+    const compressed = method === 0 ? raw : deflateRawSync(raw);
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(method, 8);
+    local.writeUInt16LE(0, 10); // mod time
+    local.writeUInt16LE(0, 12); // mod date
+    local.writeUInt32LE(crc32(raw), 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(raw.length, 22);
+    local.writeUInt16LE(nameBytes.length, 26);
+    local.writeUInt16LE(0, 28); // extra length
+    localChunks.push(local, nameBytes, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4); // version made by
+    central.writeUInt16LE(20, 6); // version needed
+    central.writeUInt16LE(0, 8); // flags
+    central.writeUInt16LE(method, 10);
+    central.writeUInt16LE(0, 12);
+    central.writeUInt16LE(0, 14);
+    central.writeUInt32LE(crc32(raw), 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(raw.length, 24);
+    central.writeUInt16LE(nameBytes.length, 28);
+    central.writeUInt16LE(0, 30); // extra
+    central.writeUInt16LE(0, 32); // comment
+    central.writeUInt16LE(0, 34); // disk number
+    central.writeUInt16LE(0, 36); // internal attrs
+    central.writeUInt32LE(0, 38); // external attrs
+    central.writeUInt32LE(offset, 42);
+    centralChunks.push(central, nameBytes);
+
+    offset += local.length + nameBytes.length + compressed.length;
+  }
+
+  const localBuf = Buffer.concat(localChunks);
+  const centralBuf = Buffer.concat(centralChunks);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // central dir disk
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(centralBuf.length, 12);
+  eocd.writeUInt32LE(localBuf.length, 16);
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([localBuf, centralBuf, eocd]);
+}

--- a/sdk/tests/zipFixtures.ts
+++ b/sdk/tests/zipFixtures.ts
@@ -6,6 +6,14 @@ export interface ZipInput {
   content: string | Buffer;
   /** 0 = stored, 8 = deflate. Defaults to deflate. */
   method?: 0 | 8;
+  /** General purpose bit flag, e.g. 0x0001 to mark the entry encrypted. */
+  flags?: number;
+}
+
+/** Options for the archive as a whole. */
+export interface ZipOptions {
+  /** Trailing archive comment, recorded in the EOCD comment length. */
+  comment?: string;
 }
 
 /**
@@ -13,13 +21,14 @@ export interface ZipInput {
  * returns, so the reader can be exercised without checking binary fixtures
  * into git.
  */
-export function buildZip(files: ZipInput[]): Buffer {
+export function buildZip(files: ZipInput[], options: ZipOptions = {}): Buffer {
   const localChunks: Buffer[] = [];
   const centralChunks: Buffer[] = [];
   let offset = 0;
 
   for (const file of files) {
     const method = file.method ?? 8;
+    const flags = file.flags ?? 0;
     const nameBytes = Buffer.from(file.name, 'utf8');
     const raw = Buffer.isBuffer(file.content) ? file.content : Buffer.from(file.content, 'utf8');
     const compressed = method === 0 ? raw : deflateRawSync(raw);
@@ -27,7 +36,7 @@ export function buildZip(files: ZipInput[]): Buffer {
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);
     local.writeUInt16LE(20, 4); // version needed
-    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(flags, 6);
     local.writeUInt16LE(method, 8);
     local.writeUInt16LE(0, 10); // mod time
     local.writeUInt16LE(0, 12); // mod date
@@ -42,7 +51,7 @@ export function buildZip(files: ZipInput[]): Buffer {
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(20, 4); // version made by
     central.writeUInt16LE(20, 6); // version needed
-    central.writeUInt16LE(0, 8); // flags
+    central.writeUInt16LE(flags, 8);
     central.writeUInt16LE(method, 10);
     central.writeUInt16LE(0, 12);
     central.writeUInt16LE(0, 14);
@@ -64,6 +73,7 @@ export function buildZip(files: ZipInput[]): Buffer {
   const localBuf = Buffer.concat(localChunks);
   const centralBuf = Buffer.concat(centralChunks);
 
+  const comment = Buffer.from(options.comment ?? '', 'utf8');
   const eocd = Buffer.alloc(22);
   eocd.writeUInt32LE(0x06054b50, 0);
   eocd.writeUInt16LE(0, 4); // disk number
@@ -72,7 +82,7 @@ export function buildZip(files: ZipInput[]): Buffer {
   eocd.writeUInt16LE(files.length, 10);
   eocd.writeUInt32LE(centralBuf.length, 12);
   eocd.writeUInt32LE(localBuf.length, 16);
-  eocd.writeUInt16LE(0, 20); // comment length
+  eocd.writeUInt16LE(comment.length, 20);
 
-  return Buffer.concat([localBuf, centralBuf, eocd]);
+  return Buffer.concat([localBuf, centralBuf, eocd, comment]);
 }

--- a/sdk/tests/zipReader.unit.test.ts
+++ b/sdk/tests/zipReader.unit.test.ts
@@ -40,6 +40,51 @@ describe('readZipEntries', () => {
     expect(() => readZipEntries(Buffer.alloc(0))).toThrow(AnafValidationError);
   });
 
+  it('reads an archive carrying a trailing comment', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }], { comment: 'produced by ANAF' });
+
+    expect(readZipEntries(zip)[0].data.toString('utf8')).toBe(INVOICE_XML);
+  });
+
+  it('ignores an EOCD signature that occurs inside the archive comment', () => {
+    // Those four bytes are legal comment content; only the record whose
+    // comment length accounts for the remaining bytes is the real EOCD.
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }], { comment: 'note: PK\u0005\u0006 appears here' });
+
+    expect(readZipEntries(zip)[0].data.toString('utf8')).toBe(INVOICE_XML);
+  });
+
+  it('rejects an encrypted entry rather than returning ciphertext', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML, flags: 0x0001 }]);
+
+    expect(() => readZipEntries(zip)).toThrow(/encrypted/);
+  });
+
+  it('rejects a ZIP64 archive with a clear message', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }]);
+    const eocd = zip.length - 22;
+    zip.writeUInt32LE(0xffffffff, eocd + 16); // central directory offset escape
+
+    expect(() => readZipEntries(zip)).toThrow(/ZIP64/);
+  });
+
+  it('rejects a ZIP64 archive flagged by its entry count', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }]);
+    const eocd = zip.length - 22;
+    zip.writeUInt16LE(0xffff, eocd + 10);
+
+    expect(() => readZipEntries(zip)).toThrow(/ZIP64/);
+  });
+
+  it('rejects a central directory whose name length overruns the buffer', () => {
+    const zip = buildZip([{ name: '4013735587.xml', content: INVOICE_XML }]);
+    const eocd = zip.length - 22;
+    const centralDirOffset = zip.readUInt32LE(eocd + 16);
+    zip.writeUInt16LE(60000, centralDirOffset + 28); // name length
+
+    expect(() => readZipEntries(zip)).toThrow(/corrupt central directory/);
+  });
+
   it('rejects a truncated archive', () => {
     const zip = buildZip([{ name: 'a.xml', content: INVOICE_XML }]);
     const truncated = Buffer.concat([Buffer.alloc(0), zip.subarray(10)]);
@@ -77,6 +122,47 @@ describe('extractInvoiceXml', () => {
     const zip = buildZip([{ name: 'semnatura_1.xml', content: SIGNATURE_XML }]);
 
     expect(extractInvoiceXml(zip)).toBe(SIGNATURE_XML);
+  });
+
+  it('picks the invoice by root element, not by position', () => {
+    // A third XML sorted ahead of the invoice must not win on order alone.
+    const zip = buildZip([
+      { name: '0-errors.xml', content: '<?xml version="1.0"?><Errors><Error>nope</Error></Errors>' },
+      { name: '1-invoice.xml', content: INVOICE_XML },
+      { name: 'semnatura_1.xml', content: SIGNATURE_XML },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(INVOICE_XML);
+  });
+
+  it('picks a credit note by root element', () => {
+    const creditNote = '<?xml version="1.0"?><CreditNote><ID>CN-1</ID></CreditNote>';
+    const zip = buildZip([
+      { name: 'attachment.xml', content: '<?xml version="1.0"?><Anexa/>' },
+      { name: '2.xml', content: creditNote },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(creditNote);
+  });
+
+  it('matches a namespace-prefixed root element', () => {
+    const prefixed = '<?xml version="1.0"?><!-- ANAF --><ubl:Invoice xmlns:ubl="urn:oasis"><ID>1</ID></ubl:Invoice>';
+    const zip = buildZip([
+      { name: '0-other.xml', content: '<?xml version="1.0"?><Other/>' },
+      { name: '1.xml', content: prefixed },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(prefixed);
+  });
+
+  it('falls back to the first non-signature XML when no root element matches', () => {
+    const other = '<?xml version="1.0"?><Other>payload</Other>';
+    const zip = buildZip([
+      { name: 'semnatura_1.xml', content: SIGNATURE_XML },
+      { name: '1.xml', content: other },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(other);
   });
 
   it('throws when the archive holds no XML', () => {

--- a/sdk/tests/zipReader.unit.test.ts
+++ b/sdk/tests/zipReader.unit.test.ts
@@ -1,0 +1,87 @@
+import { buildZip } from './zipFixtures';
+import { readZipEntries, extractInvoiceXml } from '../src/utils/zipReader';
+import { AnafValidationError } from '../src/errors';
+
+const INVOICE_XML = '<?xml version="1.0" encoding="UTF-8"?><Invoice><ID>FCT-1</ID></Invoice>';
+const SIGNATURE_XML = '<?xml version="1.0"?><Signature>sig</Signature>';
+
+describe('readZipEntries', () => {
+  it('reads deflate-compressed entries', () => {
+    const zip = buildZip([{ name: '4013735587.xml', content: INVOICE_XML }]);
+    const entries = readZipEntries(zip);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('4013735587.xml');
+    expect(entries[0].data.toString('utf8')).toBe(INVOICE_XML);
+  });
+
+  it('reads stored (uncompressed) entries', () => {
+    const zip = buildZip([{ name: 'plain.xml', content: INVOICE_XML, method: 0 }]);
+    const entries = readZipEntries(zip);
+
+    expect(entries[0].data.toString('utf8')).toBe(INVOICE_XML);
+  });
+
+  it('reads multiple entries', () => {
+    const zip = buildZip([
+      { name: '4013735587.xml', content: INVOICE_XML },
+      { name: 'semnatura_4013735587.xml', content: SIGNATURE_XML },
+    ]);
+    const entries = readZipEntries(zip);
+
+    expect(entries.map((e) => e.name)).toEqual(['4013735587.xml', 'semnatura_4013735587.xml']);
+  });
+
+  it('rejects a buffer that is not a ZIP archive', () => {
+    expect(() => readZipEntries(Buffer.from('not a zip at all'))).toThrow(AnafValidationError);
+  });
+
+  it('rejects an empty buffer', () => {
+    expect(() => readZipEntries(Buffer.alloc(0))).toThrow(AnafValidationError);
+  });
+
+  it('rejects a truncated archive', () => {
+    const zip = buildZip([{ name: 'a.xml', content: INVOICE_XML }]);
+    const truncated = Buffer.concat([Buffer.alloc(0), zip.subarray(10)]);
+    expect(() => readZipEntries(truncated)).toThrow(AnafValidationError);
+  });
+});
+
+describe('extractInvoiceXml', () => {
+  it('picks the invoice XML over the detached signature', () => {
+    const zip = buildZip([
+      { name: 'semnatura_4013735587.xml', content: SIGNATURE_XML },
+      { name: '4013735587.xml', content: INVOICE_XML },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(INVOICE_XML);
+  });
+
+  it('strips a UTF-8 byte order mark', () => {
+    const withBom = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(INVOICE_XML, 'utf8')]);
+    const zip = buildZip([{ name: '1.xml', content: withBom }]);
+
+    expect(extractInvoiceXml(zip)).toBe(INVOICE_XML);
+  });
+
+  it('ignores non-XML entries', () => {
+    const zip = buildZip([
+      { name: 'readme.txt', content: 'ignore me' },
+      { name: '1.xml', content: INVOICE_XML },
+    ]);
+
+    expect(extractInvoiceXml(zip)).toBe(INVOICE_XML);
+  });
+
+  it('falls back to the signature when it is the only XML present', () => {
+    const zip = buildZip([{ name: 'semnatura_1.xml', content: SIGNATURE_XML }]);
+
+    expect(extractInvoiceXml(zip)).toBe(SIGNATURE_XML);
+  });
+
+  it('throws when the archive holds no XML', () => {
+    const zip = buildZip([{ name: 'readme.txt', content: 'nothing here' }]);
+
+    expect(() => extractInvoiceXml(zip)).toThrow(/No XML document found/);
+  });
+});

--- a/sdk/tests/zipReader.unit.test.ts
+++ b/sdk/tests/zipReader.unit.test.ts
@@ -85,6 +85,29 @@ describe('readZipEntries', () => {
     expect(() => readZipEntries(zip)).toThrow(/corrupt central directory/);
   });
 
+  it('rejects an unsupported compression method', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML, method: 12 }]); // 12 = bzip2
+
+    expect(() => readZipEntries(zip)).toThrow(/Unsupported ZIP compression method 12/);
+  });
+
+  it('rejects a central directory that overruns its declared size', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }]);
+    const eocd = zip.length - 22;
+    zip.writeUInt32LE(zip.readUInt32LE(eocd + 12) - 1, eocd + 12); // shrink declared size
+
+    expect(() => readZipEntries(zip)).toThrow(/corrupt central directory/);
+  });
+
+  it('rejects a deflate entry that declares more than the size ceiling', () => {
+    const zip = buildZip([{ name: '1.xml', content: INVOICE_XML }]);
+    const eocd = zip.length - 22;
+    const centralDirOffset = zip.readUInt32LE(eocd + 16);
+    zip.writeUInt32LE(0x7fffffff, centralDirOffset + 24); // uncompressed size
+
+    expect(() => readZipEntries(zip)).toThrow(/exceeds the \d+-byte limit/);
+  });
+
   it('rejects a truncated archive', () => {
     const zip = buildZip([{ name: 'a.xml', content: INVOICE_XML }]);
     const truncated = Buffer.concat([Buffer.alloc(0), zip.subarray(10)]);


### PR DESCRIPTION
Closes #15 — thanks @haiganu for the request.

## Why

ANAF serves downloads as a ZIP holding the invoice XML plus a detached signature, and its transform service renders a PDF from XML. Both halves already existed, but nothing tied them together: getting a readable invoice meant unzipping by hand between two calls, and the MCP server had no PDF path at all.

## SDK

- **`sdk/src/utils/zipReader.ts`** — dependency-free ZIP reader (central-directory walk; stored + deflate via `node:zlib`) and `extractInvoiceXml`, which picks the invoice over `semnatura_*.xml` and strips a BOM. No new dependency, which matters because the CLI inlines the SDK into a single esbuild bundle and the SEA binaries.
- **`EfacturaClient.downloadDocumentXml(downloadId)`** returns the invoice XML straight from the archive; mirrored on the `AnafEfacturaClient` facade.
- `readZipEntries` / `extractInvoiceXml` exported for callers that already hold an archive.

## CLI

`anaf-cli efactura download --as zip|xml|pdf`, default `zip`, so existing invocations are unchanged.

```bash
anaf-cli efactura download --download-id 67890 --as xml --out invoice.xml
anaf-cli efactura download --download-id 67890 --as pdf --out invoice.pdf
```

`--as pdf` downloads, unwraps, and renders through the transform service, honouring `--standard FACT1|FCN` and `--no-validation` (same flags as `efactura pdf`).

The flag is `--as` rather than `--format` on purpose: `--format` is the global output-format flag and `strictifyCommands` copies it onto every leaf command, so reusing the name would have silently taken `--format json` away from this command.

## MCP

New `anaf_download_invoice_pdf` tool (`download_id`, `output_path`, `standard`, `no_validation`) — writes the rendered PDF and returns `{ path, bytes, downloadId, standard }`.

## Tests

- ZIP reader over a generated archive: deflate, stored, multi-entry, truncated, non-ZIP, BOM, signature-only fallback, no-XML.
- Client-level unwrap and non-ZIP rejection against mocked `fetch`.
- CLI service (`downloadXml`, `downloadPdf`, error mapping) and command layer (both new formats, flag pass-through, bad `--as` value).
- MCP handler including the `no_validation` route and both failure paths.

`pnpm run lint` clean; SDK 275 unit tests, CLI 376, MCP 48 — all passing. Also exercised the built CLI (`--as docx` errors with exit 2 while `--format json` still selects JSON output) and the built MCP server's `tools/list` to confirm the new tool's JSON schema and descriptions.

No version bumps or CHANGELOG entry — this repo does those in a separate `chore(release)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hd3vWiNApMeSwCBEqtksA

---
_Generated by [Claude Code](https://claude.ai/code/session_012hd3vWiNApMeSwCBEqtksA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PDF invoice and credit note downloads through the CLI and MCP tools.
  * Added XML invoice downloads and extraction from ZIP archives.
  * Added PDF rendering options for document standards and validation controls.
  * Added SDK support for downloading invoice XML and reading ZIP contents.
* **Bug Fixes**
  * Improved validation and error handling for malformed archives, invalid inputs, and download or conversion failures.
* **Documentation**
  * Updated CLI, SDK, MCP, and invoice guidance for ZIP, XML, and PDF downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->