### PR TITLE
chore(release): sdk 1.6.0, cli 1.2.0, mcp 1.2.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "CLI for the ANAF e-Factura SDK (anaf-ts-sdk)",
   "license": "MIT",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "MCP server for the ANAF e-Factura SDK — exposes lookup, UBL, upload, status, download, messages, validate as tools",
   "license": "MIT",
   "repository": {

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-09-05
+
+### Added
+
+- **`EfacturaClient.downloadDocumentXml(downloadId)`** — downloads a document and
+  returns the invoice XML unwrapped from ANAF's ZIP archive, which holds the
+  invoice plus a detached `semnatura_*.xml` signature. Mirrored on the
+  `AnafEfacturaClient` facade. Pairs with `convertXmlToPdf` to turn a download
+  into a PDF without unzipping by hand:
+
+  ```typescript
+  const xml = await client.downloadDocumentXml(status.idDescarcare);
+  const pdf = await client.convertXmlToPdf(xml, 'FACT1');
+  ```
+
+- **`readZipEntries` / `extractInvoiceXml`** exported for callers that already
+  hold an archive. The reader is dependency-free — it walks the central
+  directory and inflates with `node:zlib` — so nothing new is added to the
+  bundles that inline this SDK.
+
+  `extractInvoiceXml` selects the invoice by root element (`Invoice` or
+  `CreditNote`, namespace prefix ignored) rather than by position, so an archive
+  carrying an extra document alongside the invoice still yields the invoice.
+  It rejects ZIP64, encrypted entries, unsupported compression methods, and
+  archives whose central directory does not match its declared bounds, and caps
+  a single decompressed entry at 64 MB.
+
 ## [1.5.1] - 2026-08-06
 
 ### Fixed

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@florinszilagyi/anaf-ts-sdk",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Complete TypeScript SDK for Romanian ANAF API -E-Factura, Company checks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Ships the PDF download feature from #18 (e2d3b1c) to all three published packages.

Minor bumps rather than patch: the change is additive — `efactura download` without `--as` behaves exactly as before, and no SDK signature changed.

| Package | Version | Why it needs republishing |
|---|---|---|
| sdk | 1.5.1 → 1.6.0 | Adds `EfacturaClient.downloadDocumentXml` and the exported ZIP utilities. |
| cli | 1.1.1 → 1.2.0 | Inlines the SDK into `dist/bin/anaf-cli.cjs` via esbuild at build time and ships it again in the SEA binaries, so a republish is how its users get `--as xml\|pdf`. |
| mcp | 1.1.1 → 1.2.0 | Resolves the SDK via `workspace:*`, so its published artifact embeds whatever SDK is current at build time; a republish is how its users get `anaf_download_invoice_pdf`. |

Contents: version bumps in the three `package.json` files plus a `1.6.0` entry in `sdk/CHANGELOG.md`. No source changes.

Verified on this commit: SDK 288 tests, CLI 384, MCP 51, lint and `gen-docs:check` clean, and the built binary reports `1.2.0`.

Tags `sdk-v1.6.0`, `cli-v1.2.0`, `mcp-v1.2.0` go on main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hd3vWiNApMeSwCBEqtksA

---
_Generated by [Claude Code](https://claude.ai/code/session_012hd3vWiNApMeSwCBEqtksA)_